### PR TITLE
Hawk handler: copy http request body instead of consuming it

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ dependencies:
       "$CIRCLE_BUILD_URL" > version.json
     - cp version.json $CIRCLE_ARTIFACTS
     - go get -d
+    - cd cmd/tigerblood && go get -d
     - CGO_ENABLED=0 go build --ldflags '-extldflags "-static"' ./cmd/tigerblood/
     - docker build -t "app:build" .
     - test -e $CIRCLE_ARTIFACTS/bin || mkdir -p $CIRCLE_ARTIFACTS/bin


### PR DESCRIPTION
Fixes #5 

Simply calling io.Copy on the buffer consumes all of the contents.
