### PR TITLE
Improved configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ RUN addgroup -g 10001 app && \
 
 COPY version.json /app/version.json
 COPY tigerblood /app/tigerblood
+COPY config.yml /app/config.yml
 
 USER app

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -17,7 +17,7 @@ func main() {
 		log.Println("Error loading config file:", err)
 	}
 	if config.DatabaseDsn == "" {
-		log.Println("No database DSN found")
+		log.Fatal("No database DSN found")
 	}
 	db, err := tigerblood.NewDB(config.DatabaseDsn)
 	if err != nil {

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		log.Fatal(fmt.Errorf("Could not connect to the database: %s", err))
 	}
-	db.SetMaxOpenConns(80)
+	db.SetMaxOpenConns(config.DatabaseMaxOpenConns)
 	var statsdClient *statsd.Client
 	if config.StatsdAddress != "" {
 		statsdClient, err = statsd.New(config.StatsdAddress)

--- a/config.go
+++ b/config.go
@@ -1,5 +1,38 @@
 package tigerblood
 
+import (
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+)
+
 type Config struct {
-	Credentials map[string]string
+	Credentials   map[string]string
+	BindAddress   string
+	DatabaseDsn   string
+	StatsdAddress string
+	EnableHawk    bool
+}
+
+// LoadConfigFromPath loads a yaml config file from the provided path, overriding values based on environment variables
+func LoadConfigFromPath(path string) (Config, error) {
+	var config Config
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return config, err
+	}
+	err = yaml.Unmarshal(bytes, &config)
+	if dsn, found := os.LookupEnv("TIGERBLOOD_DSN"); found {
+		config.DatabaseDsn = dsn
+	}
+	if statsdAddr, found := os.LookupEnv("TIGERBLOOD_STATSD_ADDR"); found {
+		config.StatsdAddress = statsdAddr
+	}
+	if bindAddr, found := os.LookupEnv("TIGERBLOOD_BIND_ADDR"); found {
+		config.BindAddress = bindAddr
+	}
+	if hawk, _ := os.LookupEnv("TIGERBLOOD_ENABLE_HAWK"); hawk == "yes" {
+		config.EnableHawk = true
+	}
+	return config, err
 }

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,4 @@
+bindAddress: 127.0.0.1:8000
+enableHawk: false
+credentials:
+  root: toor


### PR DESCRIPTION
Everything except Hawk credentials can now be configured either via the YAML config file or via environment variables. The latter take precedence. A default config file has been added, which is also copied to the docker container, so Hawk is disabled as a default.
