### PR TITLE
Violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,11 @@ reputation.
 {
   "type": "object",
   "properties": {
-    "IP": {
-      "type": "string"
-    },
     "Violation": {
       "type": "string"
     }
   },
   "required": [
-    "IP",
     "Violation"
   ]
 }
@@ -194,4 +190,4 @@ reputation.
 * Response body: None
 * Successful response status code: 204 No Content
 
-Example: `curl -d '{"IP": "240.0.0.1", "violation": "password-check-rate-limited-exceeded"}' -X PUT http://tigerblood/violations/240.0.0.1 --header "Authorization: {YOUR_HAWK_HEADER}"`
+Example: `curl -d '{"Violation": "password-check-rate-limited-exceeded"}' -X PUT http://tigerblood/violations/240.0.0.1 --header "Authorization: {YOUR_HAWK_HEADER}"`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you don't want to install postgres, you can do this from a docker container:
 - From this shell, run `psql -U postgres`. You should get a postgres prompt.
 - Run the following SQL to create the `tigerblood` user and database:
   ```sql
-  
+
   CREATE ROLE tigerblood WITH LOGIN;
   CREATE DATABASE tigerblood;
   GRANT ALL PRIVILEGES ON DATABASE tigerblood TO tigerblood;
@@ -161,3 +161,37 @@ Example: `curl http://tigerblood/__heartbeat__`
 * Successful response status code: 200
 
 Example: `curl http://tigerblood/__version__`
+
+#### PUT /violations/{ip}
+
+Sets or updates the reputation for an IP address or network to the
+reputation for the violation type found in the
+`violation_reputation_weights` table if it is lower than the current
+reputation.
+
+
+* Request parameters: None
+* Request body: a JSON object with the schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "IP": {
+      "type": "string"
+    },
+    "Violation": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "IP",
+    "Violation"
+  ]
+}
+```
+
+* Response body: None
+* Successful response status code: 204 No Content
+
+Example: `curl -d '{"IP": "240.0.0.1", "violation": "password-check-rate-limited-exceeded"}' -X PUT http://tigerblood/violations/240.0.0.1 --header "Authorization: {YOUR_HAWK_HEADER}"`


### PR DESCRIPTION
Refs: #16 

Violations we can add from [FxA ip_record](https://github.com/mozilla/fxa-customs-server/blob/master/lib/ip_record.js#L175-L207):

blocked
account-status-check-rate-limit-exceeded
verify-code-check-rate-limited-exceeded
password-check-rate-limited-exceeded

I haven't run load tests or decided on what violation types to load in the database and how to do that.
