### PR TITLE
409 Conflict inserting inserted reputation

### DIFF
--- a/tigerblood.go
+++ b/tigerblood.go
@@ -135,6 +135,9 @@ func (h *TigerbloodHandler) CreateReputation(w http.ResponseWriter, r *http.Requ
 	if _, ok := err.(CheckViolationError); ok {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("Reputation is outside of valid range [0-100]"))
+	} else if _, ok := err.(DuplicateKeyError); ok {
+		w.WriteHeader(http.StatusConflict)
+		w.Write([]byte("Reputation is already set for that IP."))
 	} else if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}

--- a/tigerblood_test.go
+++ b/tigerblood_test.go
@@ -125,6 +125,10 @@ func TestCreateEntry(t *testing.T) {
 	entry, err := db.SelectSmallestMatchingSubnet("192.168.0.1")
 	assert.Nil(t, err)
 	assert.Equal(t, uint(20), entry.Reputation)
+
+	recorder = httptest.ResponseRecorder{}
+	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
+	assert.Equal(t, http.StatusConflict, recorder.Code)
 }
 
 func TestCreateEntryInvalidReputation(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Greg Guthe gguthe@mozilla.com

Refs: https://github.com/mozilla-services/tigerblood/pull/18#discussion_r85151990

Lets us distinguish server errors from already inserted IP/Reputations.
