### PR TITLE
publish go runtime stats to datadog

### DIFF
--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"github.com/DataDog/datadog-go/statsd"
+	_ "github.com/bmhatfield/go-runtime-metrics"
 	"github.com/spf13/viper"
+	"flag"
 	"go.mozilla.org/tigerblood"
 	"log"
 	"net/http"
@@ -15,12 +17,28 @@ func main() {
 	viper.SetDefault("BIND_ADDR", "127.0.0.1:8080")
 	viper.SetDefault("STATSD_ADDR", "127.0.0.1:8125")
 	viper.SetDefault("HAWK", false)
+	viper.SetDefault("PUBLISH_RUNTIME_STATS", false)
+	viper.SetDefault("RUNTIME_PAUSE_INTERVAL", 10)
+	viper.SetDefault("RUNTIME_CPU", true)
+	viper.SetDefault("RUNTIME_MEM", true)
+	viper.SetDefault("RUNTIME_GC", true)
+
 	viper.SetEnvPrefix("tigerblood")
 	viper.AutomaticEnv()
 	err := viper.ReadInConfig()
 	if err != nil {
 		log.Fatalf("Error loading config file: %s", err)
 	}
+
+	// Set flags for go-runtime-metrics
+	flag.Set("statsd", viper.GetString("STATSD_ADDR"))
+	flag.Set("metric-prefix", "tigerblood")
+	flag.Set("pause", viper.GetString("RUNTIME_PAUSE_INTERVAL"))
+	flag.Set("publish-runtime-stats", viper.GetString("PUBLISH_RUNTIME_STATS"))
+	flag.Set("cpu", viper.GetString("RUNTIME_CPU"))
+	flag.Set("mem", viper.GetString("RUNTIME_MEM"))
+	flag.Set("gc", viper.GetString("RUNTIME_GC"))
+
 	if !viper.IsSet("DSN") {
 		log.Fatalf("No DSN found. Cannot continue without a database")
 	}
@@ -34,6 +52,7 @@ func main() {
 	if viper.IsSet("STATSD_ADDR") {
 		statsdClient, err = statsd.New(viper.GetString("STATSD_ADDR"))
 		statsdClient.Namespace = "tigerblood."
+		flag.Parse() // kick off go-runtime-stats collector
 	} else {
 		log.Println("statsd not found")
 	}


### PR DESCRIPTION
As discussed in #go it'd be interesting to publish GC stats to datadog.

This propagates go-runtime-stats flags and disables it by default.

Functional Tests (after `go get github.com/bmhatfield/go-runtime-metrics`):

Running with go-runtime-stats modified locally to print the flags it receives:

```
~GOPATH - [memstats-to-datadog●] » TIGERBLOOD_DSN="user=tigerblood dbname=tigerblood sslmode=disable" TIGERBLOOD_PUBLISH_RUNTIME_STATS=1 TIGERBLOOD_STATSD_ADDR=0.0.0.0:39209 ./tigerblood
2016/12/02 10:35:29 in runstats
2016/12/02 10:35:30 in runstats flags 0.0.0.0:39209 tigerblood. 10 true true true true
2016/12/02 10:35:30 g2s: publish: write udp 127.0.0.1:57173->127.0.0.1:39209: write: connection refused
2016/12/02 10:35:30 g2s: publish: write udp 127.0.0.1:57173->127.0.0.1:39209: write: connection refused
...
^C
~GOPATH - [memstats-to-datadog●] » TIGERBLOOD_DSN="user=tigerblood dbname=tigerblood sslmode=disable" ./tigerblood
2016/12/02 10:35:47 in runstats
2016/12/02 10:35:48 in runstats flags 127.0.0.1:8125 tigerblood. 10 false true true true
~GOPATH - [memstats-to-datadog●] » TIGERBLOOD_DSN="user=tigerblood dbname=tigerblood sslmode=disable" ./tigerblood
2016/12/02 10:36:39 in runstats
2016/12/02 10:36:40 in runstats flags 127.0.0.1:8125 tigerblood. 10 false true true true
^C
```

We'll need to add `TIGERBLOOD_PUBLISH_RUNTIME_STATS` to enable this in.

