### PR TITLE
Print config on start

### DIFF
--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -10,6 +10,17 @@ import (
 	"net/http"
 )
 
+
+
+func printConfig() {
+	log.Println("Loaded viper config:")
+	for key, value := range viper.AllSettings() {
+		if key != "credentials" {
+			log.Print("\t", key, ": ", value)
+		}
+	}
+}
+
 func main() {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
@@ -29,6 +40,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error loading config file: %s", err)
 	}
+
+	printConfig()
 
 	// Set flags for go-runtime-metrics
 	flag.Set("statsd", viper.GetString("STATSD_ADDR"))

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -18,7 +18,10 @@ import (
 func printConfig() {
 	log.Println("Loaded viper config:")
 	for key, value := range viper.AllSettings() {
-		if key != "credentials" {
+		switch key {
+		case "credentials":  // skip sensitive keys
+		case "dsn":
+		default:
 			log.Print("\t", key, ": ", value)
 		}
 	}

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"github.com/DataDog/datadog-go/statsd"
-	_ "github.com/bmhatfield/go-runtime-metrics"
+	"github.com/bmhatfield/go-runtime-metrics/collector"
 	"github.com/spf13/viper"
-	"flag"
 	"go.mozilla.org/tigerblood"
+	"github.com/peterbourgon/g2s"
+	"fmt"
 	"log"
+	"time"
+	"strconv"
 	"net/http"
 )
 
@@ -21,12 +24,31 @@ func printConfig() {
 	}
 }
 
+func startRuntimeCollector() {
+	statsd_addr := viper.GetString("STATSD_ADDR")
+	s, err := g2s.Dial("udp", statsd_addr)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to connect to Statsd on %s - %s", statsd_addr, err))
+	}
+
+	gaugeFunc := func(key string, val uint64) {
+		s.Gauge(1.0, viper.GetString("STATSD_NAMESPACE")+key, strconv.FormatUint(val, 10))
+	}
+	c := collector.New(gaugeFunc)
+	c.PauseDur = time.Duration(viper.GetInt("RUNTIME_PAUSE_INTERVAL")) * time.Second
+	c.EnableCPU = viper.GetBool("RUNTIME_CPU")
+	c.EnableMem = viper.GetBool("RUNTIME_MEM")
+	c.EnableGC = viper.GetBool("RUNTIME_GC")
+	c.Run()
+}
+
 func main() {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	viper.SetDefault("DATABASE_MAX_OPEN_CONNS", 80)
 	viper.SetDefault("BIND_ADDR", "127.0.0.1:8080")
 	viper.SetDefault("STATSD_ADDR", "127.0.0.1:8125")
+	viper.SetDefault("STATSD_NAMESPACE", "tigerblood.")
 	viper.SetDefault("HAWK", false)
 	viper.SetDefault("PUBLISH_RUNTIME_STATS", false)
 	viper.SetDefault("RUNTIME_PAUSE_INTERVAL", 10)
@@ -43,15 +65,6 @@ func main() {
 
 	printConfig()
 
-	// Set flags for go-runtime-metrics
-	flag.Set("statsd", viper.GetString("STATSD_ADDR"))
-	flag.Set("metric-prefix", "tigerblood")
-	flag.Set("pause", viper.GetString("RUNTIME_PAUSE_INTERVAL"))
-	flag.Set("publish-runtime-stats", viper.GetString("PUBLISH_RUNTIME_STATS"))
-	flag.Set("cpu", viper.GetString("RUNTIME_CPU"))
-	flag.Set("mem", viper.GetString("RUNTIME_MEM"))
-	flag.Set("gc", viper.GetString("RUNTIME_GC"))
-
 	if !viper.IsSet("DSN") {
 		log.Fatalf("No DSN found. Cannot continue without a database")
 	}
@@ -64,8 +77,10 @@ func main() {
 	var statsdClient *statsd.Client
 	if viper.IsSet("STATSD_ADDR") {
 		statsdClient, err = statsd.New(viper.GetString("STATSD_ADDR"))
-		statsdClient.Namespace = "tigerblood."
-		flag.Parse() // kick off go-runtime-stats collector
+		statsdClient.Namespace = viper.GetString("STATSD_NAMESPACE")
+		if viper.GetBool("PUBLISH_RUNTIME_STATS") {
+			go startRuntimeCollector()
+		}
 	} else {
 		log.Println("statsd not found")
 	}
@@ -81,6 +96,7 @@ func main() {
 		handler = tigerblood.NewHawkHandler(handler, credentials)
 	}
 	http.HandleFunc("/", handler.ServeHTTP)
+	log.Printf("Listening on %s", viper.GetString("BIND_ADDR"))
 	err = http.ListenAndServe(viper.GetString("BIND_ADDR"), nil)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -62,6 +62,8 @@ func main() {
 		credentials := viper.GetStringMapString("CREDENTIALS")
 		if len(credentials) == 0 {
 			log.Fatal("Hawk was enabled, but no credentials were found.")
+		} else {
+			log.Printf("Hawk enabled with %d credentials.", len(credentials))
 		}
 		handler = tigerblood.NewHawkHandler(handler, credentials)
 	}


### PR DESCRIPTION
Fixes for breaking the deploy and debugging in: https://github.com/mozilla-services/cloudops-deployment/pull/298

Changes:
* print viper config except creds map on start (DSN isn't included for some reason)
* log number of loaded credentials
* log addr and port the web server listens on
* use runtime statsd collector directly instead of trying to hack options together for `flag` and to fix the `--config-file` option

Functional Tests:

Start server and confirm runtime statsd options are passed through:

```
» CGO_ENABLED=0 go build --ldflags '-extldflags "-static"' ./cmd/tigerblood/ && TIGERBLOOD_DSN="us
er=tigerblood dbname=tigerblood sslmode=disable" TIGERBLOOD_PUBLISH_RUNTIME_STATS=1 TIGERBLOOD_STATSD_ADDR=0.0.0.0:39209 TIGERBLOOD_H
AWK=false ./tigerblood --config-file config.yml
2016/12/16 16:43:29 Loaded viper config:
2016/12/16 16:43:29     database_max_open_conns: 80
2016/12/16 16:43:29     statsd_addr: 0.0.0.0:39209
2016/12/16 16:43:29     bind_addr: 127.0.0.1:8080
2016/12/16 16:43:29     publish_runtime_stats: 1
2016/12/16 16:43:29     statsd_namespace: tigerblood.
2016/12/16 16:43:29     runtime_gc: true
2016/12/16 16:43:29     runtime_cpu: true
2016/12/16 16:43:29     hawk: false
2016/12/16 16:43:29     runtime_mem: true
2016/12/16 16:43:29     runtime_pause_interval: 10
2016/12/16 16:43:29 Listening on 127.0.0.1:8080
2016/12/16 16:43:29 g2s: publish: write udp 127.0.0.1:58224->127.0.0.1:39209: write: connection refused
...
```

Start server and confirm runtime stats publishing can be disabled:

```
» CGO_ENABLED=0 go build --ldflags '-extldflags "-static"' ./cmd/tigerblood/ && TIGERBLOOD_DSN="user=tigerblood dbname=tigerblood sslmode=disable" TIGERBLOOD_STATSD_ADDR=0.0.0.0:39209 TIGERBLOOD_HAWK=true ./tigerblood --config-file config.yml
2016/12/16 16:44:10 Loaded viper config:
2016/12/16 16:44:10     hawk: true
2016/12/16 16:44:10     database_max_open_conns: 80
2016/12/16 16:44:10     statsd_namespace: tigerblood.
2016/12/16 16:44:10     publish_runtime_stats: false
2016/12/16 16:44:10     runtime_gc: true
2016/12/16 16:44:10     runtime_mem: true
2016/12/16 16:44:10     statsd_addr: 0.0.0.0:39209
2016/12/16 16:44:10     bind_addr: 127.0.0.1:8080
2016/12/16 16:44:10     runtime_pause_interval: 10
2016/12/16 16:44:10     runtime_cpu: true
2016/12/16 16:44:10 Hawk enabled with 1 credentials.
2016/12/16 16:44:10 Listening on 127.0.0.1:8080
```

Hit an endpoint once running:

```
» curl -vIX GET http://0.0.0.0:8080/127.0.0.1
*   Trying 0.0.0.0...
* Connected to 0.0.0.0 (127.0.0.1) port 8080 (#0)
> GET /127.0.0.1 HTTP/1.1
> Host: 0.0.0.0:8080
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 404 Not Found
HTTP/1.1 404 Not Found
< Date: Fri, 16 Dec 2016 21:45:03 GMT
Date: Fri, 16 Dec 2016 21:45:03 GMT
< Content-Length: 0
Content-Length: 0
< Content-Type: text/plain; charset=utf-8
Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host 0.0.0.0 left intact

## server log
2016/12/16 16:45:03 No entries found for IP 127.0.0.1/32
```
