### PR TITLE
db connection watchdog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+.PHONY: loadtest start-db setup-db rm-db
+
+loadtest:
+	HAWK_ID=root HAWK_KEY=toor locust --host=http://localhost:8000 -f tools/loadtesting/locustfile.py
+
+start-db:
+	docker run --detach --name postgres-ip4r -p 127.0.0.1:5432:5432 postgres-ip4r
+
+setup-db:
+	docker exec -ti postgres-ip4r bash -c 'psql -U postgres -c "CREATE ROLE tigerblood WITH LOGIN;"'
+	docker exec -ti postgres-ip4r bash -c 'psql -U postgres -c "CREATE DATABASE tigerblood;"'
+	docker exec -ti postgres-ip4r bash -c 'psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE tigerblood TO tigerblood;"'
+	docker exec -ti postgres-ip4r bash -c 'psql -U postgres tigerblood -c "CREATE EXTENSION ip4r;"'
+
+rm-db:
+	docker rm -f postgres-ip4r


### PR DESCRIPTION
The db.Ping from the heartbeat might return a cached connection and not verify that the DB is still up so we add a watchdog like: https://github.com/mozilla/tls-observatory/blob/master/tlsobs-scanner/main.go#L73-L86

Functional Test:

1. start db docker container
1. start tigerblood
1. stop db
1. tigerblood dies within 10 seconds:

```
2016/12/22 17:29:15     statsd_addr: 0.0.0.0:39209
2016/12/22 17:29:15 Hawk enabled with 1 credentials.
2016/12/22 17:29:15 Listening on 127.0.0.1:8080
2016/12/22 17:30:25 Database connection failed:dial tcp [::1]:5432: getsockopt: connection refused
```
