### PR TITLE
Read violation weights from config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ setup-db:
 
 rm-db:
 	docker rm -f postgres-ip4r
+
+test:
+	TIGERBLOOD_DSN="user=tigerblood dbname=tigerblood sslmode=disable" go test

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The config file can be JSON, TOML, YAML, HCL, or a Java properties file. Keys do
         "root": "toor"
     },
     "VIOLATION_PENALTIES": {
-        "rate-limit-exceeded": "2"
+        "rate-limit-exceeded": 2
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ The config file can be JSON, TOML, YAML, HCL, or a Java properties file. Keys do
     "HAWK": "yes",
     "CREDENTIALS": {
         "root": "toor"
+    },
+    "VIOLATION_PENALTIES": {
+        "rate-limit-exceeded": "2"
     }
 }
 ```
@@ -165,9 +168,8 @@ Example: `curl http://tigerblood/__version__`
 #### PUT /violations/{ip}
 
 Sets or updates the reputation for an IP address or network to the
-reputation for the violation type found in the
-`violation_reputation_weights` table if it is lower than the current
-reputation.
+reputation for the violation type found in the config if it is lower
+than the current reputation.
 
 
 * Request parameters: None

--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ The following configuration options are available:
 | CREDENTIALS                | A map of hawk id-keys.                                                                   | -                 |
 | DATABASE\_MAX\_OPEN\_CONNS | The maximum amount of PostgreSQL database connections tigerblood will open               | 80                |
 | BIND\_ADDR                 | The host and port tigerblood will listen on for HTTP requests                            | 127.0.0.1:8080    |
-| STATSD\_ADDR               | The host and port for statsd                                                             | 127.0.0.1:8125    |
 | DSN                        | The PostgreSQL data source name. Mandatory.                                              | -                 |
 | HAWK                       | true to enable Hawk authentication. If true is provided, credentials must be non-empty   | false             |
 | VIOLATION_PENALTIES        | A map of violation names to their reputation penalty weight 0 to 100 inclusive.          | -                 |
+| STATSD\_ADDR               | The host and port for statsd                                                             | 127.0.0.1:8125    |
+| STATSD\_NAMESPACE          | The statsd namespace prefix                                                              | tigerblood.       |
+| PUBLISH\_RUNTIME\_STATS    | true to enable sending go runtime stats to STATSD\_ADDR                                  | false             |
+| RUNTIME\_PAUSE\_INTERVAL   | How often to send go runtime stats in seconds                                            | 10                |
+| RUNTIME\_CPU               | Send `cpu.goroutines` and `cpu.cgo_calls` when runtime stats are enabled.                | true              |
+| RUNTIME\_MEM               | Send top level `mem`, `mem.heap`, and `mem.stack` stats when runtime stats are enabled.  | true              |
+| RUNTIME\_GC                | Send `mem.gc` stats when runtime stats are enabled.                                      | true              |
 
 For environment variables, the configuration options must be prefixed with "TIGERBLOOD\_", for example, the environment variable to configure the DSN is TIGERBLOOD\_DSN.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following configuration options are available:
 | STATSD\_ADDR               | The host and port for statsd                                                             | 127.0.0.1:8125    |
 | DSN                        | The PostgreSQL data source name. Mandatory.                                              | -                 |
 | HAWK                       | true to enable Hawk authentication. If true is provided, credentials must be non-empty   | false             |
+| VIOLATION_PENALTIES        | A map of violation names to their reputation penalty weight 0 to 100 inclusive.          | -                 |
 
 For environment variables, the configuration options must be prefixed with "TIGERBLOOD\_", for example, the environment variable to configure the DSN is TIGERBLOOD\_DSN.
 

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -291,8 +291,11 @@ func (h *TigerbloodHandler) UpsertReputationByViolation(w http.ResponseWriter, r
 	var penalty, ok = h.violationPenalties[entry.Violation]
 	if !ok {
 		log.Printf("Could not find violation type: %s", entry.Violation)
-		penalty = 0
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Violation type not found."))
+		return
 	}
+
 	err = h.db.InsertOrUpdateReputationPenalty(nil, ip, uint(penalty))
 	if _, ok := err.(CheckViolationError); ok {
 		w.WriteHeader(http.StatusBadRequest)

--- a/tigerblood_test.go
+++ b/tigerblood_test.go
@@ -204,10 +204,10 @@ func TestInsertReputationByViolation(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, uint(10), entry.Reputation)
 
-	// unknown violation type has no effect
+	// unknown violation type returns 400
 	recorder = httptest.ResponseRecorder{}
 	h.UpsertReputationByViolation(&recorder, httptest.NewRequest("PUT", "/violations/192.168.0.1", strings.NewReader(`{"Violation": "UnknownViolation"}`)))
-	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 
 	entry, err = db.SelectSmallestMatchingSubnet("192.168.0.1")
 	assert.Nil(t, err)

--- a/tigerblood_test.go
+++ b/tigerblood_test.go
@@ -71,7 +71,7 @@ func TestReadReputationInvalidIP(t *testing.T) {
 	assert.Nil(t, err)
 	err = db.CreateTables()
 	assert.Nil(t, err)
-	h := NewTigerbloodHandler(db, nil)
+	h := NewTigerbloodHandler(db, nil, nil)
 	h.ReadReputation(&recorder, httptest.NewRequest("GET", "/2472814.124981275", nil))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
@@ -87,7 +87,7 @@ func TestReadReputationValidIP(t *testing.T) {
 		Reputation: 50,
 	})
 	assert.Nil(t, err)
-	h := NewTigerbloodHandler(db, nil)
+	h := NewTigerbloodHandler(db, nil, nil)
 	h.ReadReputation(&recorder, httptest.NewRequest("GET", "/127.0.0.1", nil))
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Nil(t, err)
@@ -105,7 +105,7 @@ func TestReadReputationNoEntry(t *testing.T) {
 		Reputation: 50,
 	})
 	assert.Nil(t, err)
-	h := NewTigerbloodHandler(db, nil)
+	h := NewTigerbloodHandler(db, nil, nil)
 	h.ReadReputation(&recorder, httptest.NewRequest("GET", "/255.0.0.1", nil))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	assert.Nil(t, err)
@@ -118,7 +118,7 @@ func TestCreateEntry(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
-	h := NewTigerbloodHandler(db, nil)
+	h := NewTigerbloodHandler(db, nil, nil)
 	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	assert.Equal(t, http.StatusCreated, recorder.Code)
 	assert.Nil(t, err)
@@ -138,7 +138,7 @@ func TestCreateEntryInvalidReputation(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
-	h := NewTigerbloodHandler(db, nil)
+	h := NewTigerbloodHandler(db, nil, nil)
 	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 200}`)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Nil(t, err)
@@ -151,7 +151,7 @@ func TestUpdateEntry(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
-	h := NewTigerbloodHandler(db, nil)
+	h := NewTigerbloodHandler(db, nil, nil)
 	h.UpdateReputation(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 25}`)))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
@@ -171,7 +171,7 @@ func TestDeleteEntry(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
-	h := NewTigerbloodHandler(db, nil)
+	h := NewTigerbloodHandler(db, nil, nil)
 	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	recorder = httptest.ResponseRecorder{}
 	h.DeleteReputation(&recorder, httptest.NewRequest("DELETE", "/192.168.0.1", nil))
@@ -188,9 +188,14 @@ func TestInsertReputationByViolation(t *testing.T) {
 	assert.Nil(t, err)
 	err = db.EmptyTables()
 	assert.Nil(t, err)
-	assert.Nil(t, testDB.InsertViolationReputationWeightEntry(nil, ViolationReputationWeightEntry{ViolationType: "TestViolation", ReputationPenalty: 90}))
 
-	h := NewTigerbloodHandler(db, nil)
+	testViolations := map[string]uint{
+		"TestViolation": 90,
+	}
+
+	h := NewTigerbloodHandler(db, nil, testViolations)
+
+	// known violation type is subtracted from default reputation
 	recorder := httptest.ResponseRecorder{}
 	h.UpsertReputationByViolation(&recorder, httptest.NewRequest("PUT", "/violations/192.168.0.1", strings.NewReader(`{"Violation": "TestViolation"}`)))
 	assert.Equal(t, http.StatusNoContent, recorder.Code)
@@ -199,7 +204,7 @@ func TestInsertReputationByViolation(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, uint(10), entry.Reputation)
 
-	// update with unknown type
+	// unknown violation type has no effect
 	recorder = httptest.ResponseRecorder{}
 	h.UpsertReputationByViolation(&recorder, httptest.NewRequest("PUT", "/violations/192.168.0.1", strings.NewReader(`{"Violation": "UnknownViolation"}`)))
 	assert.Equal(t, http.StatusNoContent, recorder.Code)


### PR DESCRIPTION
While trying to figure out how to populate the violations table, we decided to switch to a static config to avoid having to multiple stacks trying to modify the table during deployment.

Functional Tests:

- [x] send unknown violation type and IP has default reputation (default penalty is 0) 
- [x] send known violation type (from config) and IP has reputation - penalty
- [x] sending multiple known violations do not allow for a negative reputation