### PR TITLE
tools: let healthcheck take optional args

### DIFF
--- a/tools/healthcheck/healthcheck.py
+++ b/tools/healthcheck/healthcheck.py
@@ -3,15 +3,15 @@ import requests
 import json
 
 
-def healthcheck(event, context):
+def healthcheck(ip=None, url=None):
     with open('config.json') as config_file:
         config = json.load(config_file)
     hawk_auth = HawkAuth(
         id=config['hawk_id'],
         key=config['hawk_key'])
 
-    ip = config['ip']
-    url = config['url']
+    ip = ip or config['ip']
+    url = url or config['url']
 
     get = requests.get(url + ip, auth=hawk_auth)
     if get.status_code != 404:


### PR DESCRIPTION
Functional Tests:

with a valid local config.json pointing at stage

- [x] healthcheck from config works
- [x] healthcheck from config works w/ new ip to update reputation for works
- [x] healthcheck from config works w/ new ip and tigerblood instance to hit fails
```
» python -i healthcheck.py
>>> healthcheck()
>>> healthcheck('11.1.1.1')
>>> healthcheck('11.1.1.1', 'https://example.com')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "healthcheck.py", line 16, in healthcheck
    get = requests.get(url + ip, auth=hawk_auth)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 70, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/api.py", line 56, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 488, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/sessions.py", line 609, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/requests/adapters.py", line 487, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='example.com11.1.1.1', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x10fd48cd0>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',))
>>> 
```