### PR TITLE
additional input validation

### DIFF
--- a/tigerblood.go
+++ b/tigerblood.go
@@ -140,6 +140,14 @@ func (h *TigerbloodHandler) CreateReputation(w http.ResponseWriter, r *http.Requ
 		log.Printf("Could not unmarshal request body: %s", err)
 		return
 	}
+
+	ip := net.ParseIP(entry.IP)
+	if ip == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Printf("Error getting IP from HTTP body: %s", body)
+		return
+	}
+
 	err = h.db.InsertReputationEntry(nil, entry)
 	if _, ok := err.(CheckViolationError); ok {
 		w.WriteHeader(http.StatusBadRequest)

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -141,10 +141,9 @@ func (h *TigerbloodHandler) CreateReputation(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	ip := net.ParseIP(entry.IP)
-	if ip == nil {
+	if net.ParseIP(entry.IP) == nil {
 		w.WriteHeader(http.StatusBadRequest)
-		log.Printf("Error getting IP from HTTP body: %s", body)
+		log.Printf("Error parsing invalid IP from HTTP body: %s", body)
 		return
 	}
 

--- a/tigerblood_test.go
+++ b/tigerblood_test.go
@@ -141,6 +141,19 @@ func TestCreateEntry(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, recorder.Code)
 }
 
+func TestCreateEntryInvalidIP(t *testing.T) {
+	recorder := httptest.ResponseRecorder{}
+	dsn, found := os.LookupEnv("TIGERBLOOD_DSN")
+	assert.True(t, found)
+	db, err := NewDB(dsn)
+	assert.Nil(t, err)
+	db.emptyReputationTable()
+	h := NewTigerbloodHandler(db, nil, nil)
+	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1 -- SELECT(2)", "reputation": 200}`)))
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Nil(t, err)
+}
+
 func TestCreateEntryInvalidReputation(t *testing.T) {
 	recorder := httptest.ResponseRecorder{}
 	dsn, found := os.LookupEnv("TIGERBLOOD_DSN")

--- a/tigerblood_test.go
+++ b/tigerblood_test.go
@@ -49,6 +49,16 @@ var cases = []struct {
 		"2001:db8::ff00:42:8329/128",
 		false,
 	},
+	{
+		"/127.0.0.1' or '1' = '1",
+		"",
+		true,
+	},
+	{
+		"/127.0.0.1; -- SELECT(2)",
+		"",
+		true,
+	},
 }
 
 func TestIPAddressFromHTTPPath(t *testing.T) {


### PR DESCRIPTION
Changes:

* add a couple SQL injection cases for TestIPAddressFromHTTPPath
* parse IPs before they hit the DB when creating reputation entries (i.e. for `curl -v -X POST -H 'Content-Type: application/json' -d '{"IP":"127.0.0.2; -- SELECT(2)", "Reputation": 40}' "http://localhost:8081/"` return a 400 instead of a 500 and logging `pq: invalid IP4R value: "127.0.0.2; -- SELECT(2)"`