### PR TITLE
tools: Use env vars for healthcheck

### DIFF
--- a/tools/healthcheck/README.md
+++ b/tools/healthcheck/README.md
@@ -1,3 +1,10 @@
 # Healthcheck lambda function
 
 The function inserts an IP, updates it and deletes it, ensuring each operation was successful by looking up said IP afterwards.
+
+Requires the environment vars:
+
+* HAWK_ID
+* HAWK_KEY
+* SERVICE_URL
+* TEST_IP

--- a/tools/healthcheck/config.json
+++ b/tools/healthcheck/config.json
@@ -1,6 +1,0 @@
-{
-    "hawk_id": "YOUR_HAWK_ID",
-    "hawk_key": "YOUR_HAWK_KEY",
-    "ip": "240.0.0.1",
-    "url": "https://tigerblood.stage.mozaws.net/"
-}


### PR DESCRIPTION
Have healthcheck read env vars instead of a config file. 