### PR TITLE
Decay env vars

### DIFF
--- a/tools/decay/Makefile
+++ b/tools/decay/Makefile
@@ -1,0 +1,9 @@
+build:
+	chmod +x decay.py
+	pip install psycopg2 -t .
+	zip -r tigerblood-decay.zip decay.py .
+clean:
+	rm -rf tigerblood-decay.zip *.dist-info *.pyc psychopg2/
+test:
+	DECAY_RATE=1 DB_DSN="host=127.0.0.1 user=tigerblood dbname=tigerblood sslmode=disable" python decay.py
+.PHONY: clean build

--- a/tools/decay/README.md
+++ b/tools/decay/README.md
@@ -1,3 +1,5 @@
 # Decay lambda function
 
-This AWS lambda function will increase the reputation of every single entry in the database by the `DECAY_RATE` set in the config file every time it is ran.
+This AWS lambda function will increase the reputation of every single entry in the database by the `DECAY_RATE` set in the config file every time it is run.
+
+Requires the env vars `DECAY_RATE` and `DB_DSN`.

--- a/tools/decay/decay.py
+++ b/tools/decay/decay.py
@@ -1,18 +1,25 @@
-import json
+import os
 import psycopg2
 
 
-def decay(event, context):
-    with open('config.json') as config_file:
-        config = json.load(config_file)
-    conn = psycopg2.connect(config['DB_DSN'])
-    cur = conn.cursor()
-    cur.execute(
-        """
-        UPDATE reputation
-            SET reputation = reputation + %s
-        WHERE reputation <= 100 - %s""",
-        (config['DECAY_RATE'],) * 2)
-    conn.commit()
-    cur.close()
+UPDATE_REPUTATION_SQL = """
+UPDATE reputation
+SET reputation = reputation + %s
+WHERE reputation <= 100 - %s
+"""
+
+
+def decay():
+    with psycopg2.connect(os.environ['DB_DSN']) as conn:
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_REPUTATION_SQL,
+                        (os.environ['DECAY_RATE'],) * 2)
     conn.close()
+
+
+def handler(event, context):
+    decay()
+
+
+if __name__ == '__main__':
+    decay()

--- a/tools/decay/setup.cfg
+++ b/tools/decay/setup.cfg
@@ -1,0 +1,2 @@
+[install]
+prefix=

--- a/tools/healthcheck/healthcheck.py
+++ b/tools/healthcheck/healthcheck.py
@@ -35,3 +35,7 @@ def healthcheck(ip=None, url=None, hawk_id=None, hawk_key=None):
 def handler(event, context):
     "Entrypoint for AWS Lambda function."
     healthcheck()
+
+
+if __name__ == '__main__':
+    healthcheck()


### PR DESCRIPTION
Change:
* use env var for decay lambda

Functional Test:
- [x] run `make test` against local db and reputation is incremented

r? @autrilla @jvehent 

refs: https://github.com/mozilla-services/cloudsec/issues/172 for automating the lambda deploys