### PR TITLE
fix violation type conversion

### DIFF
--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -93,14 +93,15 @@ func main() {
 	}
 
 	var penalties = make(map[string]uint)
-	for k, penalty := range viper.GetStringMap("VIOLATION_PENALTIES") {
-		penalty, err := penalty.(uint)
-		if err {
+	for k, penalty := range viper.GetStringMapString("VIOLATION_PENALTIES") {
+		penalty, err := strconv.ParseUint(penalty, 10, 64)
+		if err != nil {
 			log.Printf("Error loading violation weight %s: %s", penalty, err)
 		} else {
 			penalties[k] = uint(penalty)
 		}
 	}
+	log.Printf("loaded violation map: %s", penalties)
 	var handler http.Handler = tigerblood.NewTigerbloodHandler(db, statsdClient, penalties)
 
 	if viper.GetBool("HAWK") {


### PR DESCRIPTION
don't try to return a uint concrete type for a string

fix everything being cast to 0

Functional Test:

 - [x] for the config 

```yaml
violation_penalties:
  test_violation: "30"
  test_violation_2: "bad_val"
```

we log:

```
2017/02/08 11:04:13 Error loading violation weight %!s(uint64=0): strconv.ParseUint: parsing "bad_val": invalid syntax
2017/02/08 11:04:13 loaded violation map: map[test_violation:%!s(uint=30)]
```