### PR TITLE
Hawk: dont validate missing payload

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -86,6 +86,7 @@ func (h *HawkHandler) lookupNonce(nonce string, t time.Time, credentials *hawk.C
 	h.bloomLock.Unlock()
 	key := nonce + t.String() + credentials.ID
 	if h.bloomNow.TestString(key) || h.bloomPrev.TestString(key) {
+		log.Printf("Could not find nonce w/ key %s in bloom filters", key)
 		return false
 	}
 	h.bloomNow.AddString(key)
@@ -99,6 +100,7 @@ func (h *HawkHandler) lookupCredentials(creds *hawk.Credentials) error {
 		creds.Key = cred
 		return nil
 	}
+	log.Printf("Could not find creds w/ id %s.", creds.ID)
 	return &hawk.CredentialError{
 		Type:        hawk.UnknownID,
 		Credentials: creds,

--- a/hawk_test.go
+++ b/hawk_test.go
@@ -80,6 +80,25 @@ func TestValidPayload(t *testing.T) {
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }
 
+func TestNoPayload(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", nil)
+	assert.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	auth := hawk.NewRequestAuth(req,
+		&hawk.Credentials{
+			ID:   "fxa",
+			Key:  "foobar",
+			Hash: sha256.New,
+		},
+		0,
+	)
+	req.Header.Set("Authorization", auth.RequestHeader())
+	recorder := httptest.NewRecorder()
+	handler := NewHawkHandler(EchoHandler, map[string]string{"fxa": "foobar"})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
 func TestExpiration(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
 	assert.Nil(t, err)


### PR DESCRIPTION
This branch makes payload validation optional, since the spec says the payload is optional: https://github.com/hueniverse/hawk#payload-validation

The reference node.js client doesn't include a hash without a payload: https://github.com/hueniverse/hawk/blob/master/lib/client.js#L123

