### PR TITLE
List violation types

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,24 @@ Example: `curl http://tigerblood/__heartbeat__`
 
 Example: `curl http://tigerblood/__version__`
 
+#### GET /violations
+
+* Request parameters: None
+* Request body: a JSON object with the schema:
+
+Returns a hashmap of violation type to penalty loaded from the config e.g.
+
+```json
+{
+  "violationName": 20,
+  "testViolation": 0
+}
+```
+
+* Successful response status code: 200
+
+Example: `curl -X GET http://tigerblood/violations`
+
 #### PUT /violations/{ip}
 
 Sets or updates the reputation for an IP address or network to the

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	log "github.com/Sirupsen/logrus"
+	"go.mozilla.org/mozlogrus"
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/bmhatfield/go-runtime-metrics/collector"
 	"github.com/spf13/viper"
 	"go.mozilla.org/tigerblood"
 	"github.com/peterbourgon/g2s"
 	"fmt"
-	"log"
 	"time"
 	"strconv"
 	"net/http"
@@ -16,15 +17,17 @@ import (
 
 
 func printConfig() {
-	log.Println("Loaded viper config:")
+	var fields = log.Fields{}
 	for key, value := range viper.AllSettings() {
 		switch key {
 		case "credentials":  // skip sensitive keys
 		case "dsn":
 		default:
-			log.Print("\t", key, ": ", value)
+			fields[key] = value
 		}
 	}
+
+	log.WithFields(fields).Info("Loaded viper config:")
 }
 
 func startRuntimeCollector() {
@@ -46,6 +49,8 @@ func startRuntimeCollector() {
 }
 
 func main() {
+	mozlogrus.Enable("tigerblood")
+
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	viper.SetDefault("DATABASE_MAX_OPEN_CONNS", 80)

--- a/db.go
+++ b/db.go
@@ -1,12 +1,17 @@
 package tigerblood
 
 import (
-	"log"
+	log "github.com/Sirupsen/logrus"
+	"go.mozilla.org/mozlogrus"
 	"database/sql"
 	"fmt"
 	"github.com/lib/pq"
 	"time"
 )
+
+func init() {
+	mozlogrus.Enable("tigerblood")
+}
 
 type CheckViolationError struct {
 	Inner *pq.Error

--- a/hawk.go
+++ b/hawk.go
@@ -4,7 +4,6 @@ import (
 	"go.mozilla.org/hawk"
 	"net/http"
 	"time"
-
 	"bytes"
 	"crypto/sha256"
 	"github.com/willf/bloom"

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -1,12 +1,13 @@
 package tigerblood
 
 import (
+	log "github.com/Sirupsen/logrus"
+	"go.mozilla.org/mozlogrus"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"github.com/DataDog/datadog-go/statsd"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -14,6 +15,11 @@ import (
 	"strings"
 	"time"
 )
+
+
+func init() {
+	mozlogrus.Enable("tigerblood")
+}
 
 type TigerbloodHandler struct {
 	db			 *DB

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -76,8 +76,10 @@ func (h *TigerbloodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case r.URL.Path ==  "/__version__":
 		h.handleVersion(w, r)
 		return
-	case strings.HasPrefix(r.URL.Path, "/violations/"):
+	case strings.HasPrefix(r.URL.Path, "/violations"):
 		switch r.Method {
+		case "GET":
+			h.ListViolations(w, r)
 		case "PUT":
 			h.UpsertReputationByViolation(w, r)
 		default:
@@ -255,6 +257,19 @@ func (h *TigerbloodHandler) DeleteReputation(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+
+func (h *TigerbloodHandler) ListViolations(w http.ResponseWriter, r *http.Request) {
+	json, err := json.Marshal(h.violationPenalties)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Printf("Error marshaling violations to JSON: %s", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(json)
 }
 
 // UpsertReputationByViolation takes a JSON body from the http request

--- a/tigerblood_test.go
+++ b/tigerblood_test.go
@@ -83,7 +83,7 @@ func TestReadReputationInvalidIP(t *testing.T) {
 	err = db.CreateTables()
 	assert.Nil(t, err)
 	h := NewTigerbloodHandler(db, nil, nil)
-	h.ReadReputation(&recorder, httptest.NewRequest("GET", "/2472814.124981275", nil))
+	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/2472814.124981275", nil))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
 
@@ -99,7 +99,7 @@ func TestReadReputationValidIP(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	h := NewTigerbloodHandler(db, nil, nil)
-	h.ReadReputation(&recorder, httptest.NewRequest("GET", "/127.0.0.1", nil))
+	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/127.0.0.1", nil))
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Nil(t, err)
 }
@@ -117,7 +117,7 @@ func TestReadReputationNoEntry(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	h := NewTigerbloodHandler(db, nil, nil)
-	h.ReadReputation(&recorder, httptest.NewRequest("GET", "/255.0.0.1", nil))
+	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/255.0.0.1", nil))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	assert.Nil(t, err)
 }
@@ -130,7 +130,7 @@ func TestCreateEntry(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 	h := NewTigerbloodHandler(db, nil, nil)
-	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
+	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	assert.Equal(t, http.StatusCreated, recorder.Code)
 	assert.Nil(t, err)
 	entry, err := db.SelectSmallestMatchingSubnet("192.168.0.1")
@@ -138,7 +138,7 @@ func TestCreateEntry(t *testing.T) {
 	assert.Equal(t, uint(20), entry.Reputation)
 
 	recorder = httptest.ResponseRecorder{}
-	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
+	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	assert.Equal(t, http.StatusConflict, recorder.Code)
 }
 
@@ -150,7 +150,7 @@ func TestCreateEntryInvalidIP(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 	h := NewTigerbloodHandler(db, nil, nil)
-	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1 -- SELECT(2)", "reputation": 200}`)))
+	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1 -- SELECT(2)", "reputation": 200}`)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Nil(t, err)
 }
@@ -163,7 +163,7 @@ func TestCreateEntryInvalidReputation(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 	h := NewTigerbloodHandler(db, nil, nil)
-	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 200}`)))
+	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 200}`)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Nil(t, err)
 }
@@ -176,11 +176,11 @@ func TestUpdateEntry(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 	h := NewTigerbloodHandler(db, nil, nil)
-	h.UpdateReputation(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 25}`)))
+	h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 25}`)))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
-	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
+	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	recorder = httptest.ResponseRecorder{}
-	h.UpdateReputation(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 25}`)))
+	h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 25}`)))
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Nil(t, err)
 	entry, err := db.SelectSmallestMatchingSubnet("192.168.0.1")
@@ -196,9 +196,9 @@ func TestDeleteEntry(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 	h := NewTigerbloodHandler(db, nil, nil)
-	h.CreateReputation(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
+	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	recorder = httptest.ResponseRecorder{}
-	h.DeleteReputation(&recorder, httptest.NewRequest("DELETE", "/192.168.0.1", nil))
+	h.ServeHTTP(&recorder, httptest.NewRequest("DELETE", "/192.168.0.1", nil))
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Nil(t, err)
 	_, err = db.SelectSmallestMatchingSubnet("192.168.0.1")


### PR DESCRIPTION
Changes:

* Add a list violations endpoint requiring auth (when auth enabled) for debugging.
* Change tigerblood test to hit the routing logic
* log in mozlog format

Functional Tests:

- [x] list violations w/o hawk

```
» curl -vX GET http://localhost:8080/violations
*   Trying ::1...
* connect to ::1 port 8080 failed: Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /violations HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Fri, 17 Feb 2017 20:41:41 GMT
< Content-Length: 21
<
* Connection #0 to host localhost left intact
{"test_violation":30}% 
```

- [x] list violations requires hawk auth when enabled

```
» curl -vX GET http://localhost:8080/violations
*   Trying ::1...
* connect to ::1 port 8080 failed: Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /violations HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 401 Unauthorized
< Date: Fri, 17 Feb 2017 20:42:22 GMT
< Content-Length: 0
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host localhost left intact
```