### PR TITLE
fix segfault trying to run nil as middleware

### DIFF
--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -136,7 +136,7 @@ func main() {
 	loadConfig()
 	printConfig()
 
-	var middleware = make([]tigerblood.Middleware, 1)
+	var middleware []tigerblood.Middleware
 	middleware = append(middleware, tigerblood.RecordStartTime())
 
 	if viper.GetBool("HAWK") {


### PR DESCRIPTION
Fixes the error I was seeing in stage that prevents healthy instances coming up:

```
Mar 13 15:03:38 ip-172-31-11-131 docker[4235]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x47eb55]
Mar 13 15:03:38 ip-172-31-11-131 docker[4235]: goroutine 1 [running]:
Mar 13 15:03:38 ip-172-31-11-131 docker[4235]: panic(0x82de40, 0xc420014020)
Mar 13 15:03:38 ip-172-31-11-131 docker[4235]: /usr/local/go/src/runtime/panic.go:500 +0x1a1
Mar 13 15:03:38 ip-172-31-11-131 docker[4235]: go.mozilla.org/tigerblood.HandleWithMiddleware(0xa90e00, 0xc4201688c0, 0xc420047400, 0x
Mar 13 15:03:38 ip-172-31-11-131 docker[4235]: /home/ubuntu/.go_workspace/src/go.mozilla.org/tigerblood/middleware.go:25 +0x55
Mar 13 15:03:38 ip-172-31-11-131 docker[4235]: main.main()
Mar 13 15:03:38 ip-172-31-11-131 docker[4235]: /home/ubuntu/tigerblood/cmd/tigerblood/main.go:168 +0x458
```

r? @autrilla or @jvehent 