### PR TITLE
rm missing hawk content type header warning for GET and DELETE

### DIFF
--- a/hawk.go
+++ b/hawk.go
@@ -89,7 +89,7 @@ func RequireHawkAuth(credentials map[string]string) Middleware {
 			// Validate the payload hash of the request Content-Type and body
 			// assuming bodies will fit in memory always validate the body
 			contentType := r.Header.Get("Content-Type")
-			if contentType == "" {
+			if r.Method != "GET" && r.Method != "DELETE" && contentType == "" {
 				log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warn("hawk: missing content-type")
 			}
 


### PR DESCRIPTION
The JS client library doesn't send a body or content type header for GET and DELETE requests. 

Makes the logs less noisy by removing lines like:

```
{"Timestamp":1490196714958313784,"Time":"2017-03-22T15:31:54Z","Type":"app.log","Logger":"tigerblood","Hostname":"gguthe-23818","EnvVersion":"2.0","Pid":4876,"Severity":3,"Fields":{"errno":7,"msg":"hawk: missing content-type"}}
```