### PR TITLE
upgrade to go 1.8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
     - sudo rm -rf /usr/local/go
     - sudo tar -C /usr/local -xzf download/$GODIST
   environment:
-    GODIST: "go1.7.linux-amd64.tar.gz"
+    GODIST: "go1.8.linux-amd64.tar.gz"
     IMPORT_PATH: "go.mozilla.org/tigerblood"
     GWS: "$HOME/.go_workspace"
     TIGERBLOOD_DSN: "user=tigerblood dbname=tigerblood sslmode=disable"


### PR DESCRIPTION
Pull down 1.8 perf wins https://golang.org/doc/go1.8#performance for https://github.com/mozilla-services/foxsec/issues/260 (make tigerblood faster)

r? @autrilla 