### PR TITLE
Fix perf

### DIFF
--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -149,8 +149,7 @@ func main() {
 	var middleware []tigerblood.Middleware
 
 	if viper.GetBool("HAWK") {
-		credentials := loadCredentials()
-		middleware = append(middleware, tigerblood.RequireHawkAuth(credentials))
+		middleware = append(middleware, tigerblood.RequireHawkAuth(loadCredentials()))
 	}
 
 	tigerblood.SetProfileHandlers(viper.GetBool("PROFILE"))

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -153,9 +153,7 @@ func main() {
 		middleware = append(middleware, tigerblood.RequireHawkAuth(credentials))
 	}
 
-	db := loadDB()
-	tigerblood.SetDB(db)
-	middleware = append(middleware, tigerblood.AddDB(db))
+	tigerblood.SetDB(loadDB())
 
 	if viper.IsSet("STATSD_ADDR") {
 		statsdClient := loadStatsd()

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -156,9 +156,7 @@ func main() {
 	tigerblood.SetDB(loadDB())
 
 	if viper.IsSet("STATSD_ADDR") {
-		statsdClient := loadStatsd()
-		tigerblood.SetStatsdClient(statsdClient)
-		middleware = append(middleware, tigerblood.AddStatsdClient(statsdClient))
+		tigerblood.SetStatsdClient(loadStatsd())
 	} else {
 		log.Println("statsd not found")
 	}

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -147,7 +147,6 @@ func main() {
 	printConfig()
 
 	var middleware []tigerblood.Middleware
-	middleware = append(middleware, tigerblood.RecordStartTime())
 
 	if viper.GetBool("HAWK") {
 		credentials := loadCredentials()
@@ -166,10 +165,7 @@ func main() {
 
 	tigerblood.SetViolationPenalties(loadViolationPenalties())
 
-
 	middleware = append(middleware, tigerblood.SetResponseHeaders())
-
-	middleware = append(middleware, tigerblood.LogRequestDuration(1e7))
 
 	log.Printf("Listening on %s", viper.GetString("BIND_ADDR"))
 	err := http.ListenAndServe(

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -158,6 +158,7 @@ func main() {
 	}
 
 	penalties := loadViolationPenalties()
+	tigerblood.SetViolationPenalties(penalties)
 	middleware = append(middleware, tigerblood.AddViolations(penalties))
 
 

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -146,6 +146,7 @@ func main() {
 	}
 
 	db := loadDB()
+	tigerblood.SetDB(db)
 	middleware = append(middleware, tigerblood.AddDB(db))
 
 	if viper.IsSet("STATSD_ADDR") {

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"strconv"
 	"net/http"
+	_ "net/http/pprof"
 	"strings"
 )
 

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -61,6 +61,7 @@ func loadConfig() {
 	viper.SetDefault("RUNTIME_CPU", true)
 	viper.SetDefault("RUNTIME_MEM", true)
 	viper.SetDefault("RUNTIME_GC", true)
+	viper.SetDefault("PROFILE", false)
 
 	viper.SetEnvPrefix("tigerblood")
 	viper.AutomaticEnv()
@@ -152,6 +153,8 @@ func main() {
 		credentials := loadCredentials()
 		middleware = append(middleware, tigerblood.RequireHawkAuth(credentials))
 	}
+
+	tigerblood.SetProfileHandlers(viper.GetBool("PROFILE"))
 
 	tigerblood.SetDB(loadDB())
 

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -123,9 +123,17 @@ func loadViolationPenalties() map[string]uint {
 		parsedPenalty, err := strconv.ParseUint(penalty, 10, 64)
 		if err != nil {
 			log.Printf("Error parsing violation weight %s: %s", parsedPenalty, err)
-		} else {
-			penalties[violationType] = uint(parsedPenalty)
+			continue
 		}
+		if !tigerblood.IsValidViolationName(violationType) {
+			log.Printf("Skipping invalid violation type: %s", violationType)
+			continue
+		}
+		if !tigerblood.IsValidViolationPenalty(parsedPenalty) {
+			log.Printf("Skipping invalid violation penalty: %s", parsedPenalty)
+			continue
+		}
+		penalties[violationType] = uint(parsedPenalty)
 	}
 	log.Printf("loaded violation map: %s", penalties)
 
@@ -157,9 +165,7 @@ func main() {
 		log.Println("statsd not found")
 	}
 
-	penalties := loadViolationPenalties()
-	tigerblood.SetViolationPenalties(penalties)
-	middleware = append(middleware, tigerblood.AddViolations(penalties))
+	tigerblood.SetViolationPenalties(loadViolationPenalties())
 
 
 	middleware = append(middleware, tigerblood.SetResponseHeaders())

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -90,6 +90,18 @@ func loadDB() *tigerblood.DB {
 		log.Fatalf("Could not connect to database: %s", err)
 	}
 	db.SetMaxOpenConns(viper.GetInt("DATABASE_MAX_OPEN_CONNS"))
+	db.SetMaxIdleConns(viper.GetInt("DATABASE_MAX_IDLE_CONNS"))
+
+	if viper.GetString("DATABASE_MAXLIFETIME") == "0" {
+		db.SetConnMaxLifetime(time.Duration(0))
+	} else {
+		lifetime, err := time.ParseDuration(viper.GetString("DATABASE_CONN_MAXLIFETIME"))
+		if err != nil {
+			db.SetConnMaxLifetime(lifetime)
+		} else {
+			log.Warnf("Error parsing conn db max lifetime: %s", err)
+		}
+	}
 	return db
 }
 

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -151,6 +151,7 @@ func main() {
 
 	if viper.IsSet("STATSD_ADDR") {
 		statsdClient := loadStatsd()
+		tigerblood.SetStatsdClient(statsdClient)
 		middleware = append(middleware, tigerblood.AddStatsdClient(statsdClient))
 	} else {
 		log.Println("statsd not found")

--- a/db.go
+++ b/db.go
@@ -69,7 +69,10 @@ func NewDB(dsn string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(100)
+	db.SetMaxOpenConns(200)
+	db.SetMaxIdleConns(200)  // default is 2: https://golang.org/src/database/sql/sql.go#L652
+	db.SetConnMaxLifetime(0) // don't timeout
+
 	newDB := &DB{
 		DB: db,
 	}

--- a/errors.go
+++ b/errors.go
@@ -19,22 +19,22 @@ const (
 	HawkInvalidBodyHash
 	HawkReadBodyError
 
-	// context middleware errors
-	RequestContextMissingDB = 20
-	RequestContextMissingStatsd = iota
-	RequestContextMissingViolations = iota
+	// missing global errors usually result in warnings or 500 errors
+	MissingDB = 20
+	MissingStatsdClient = iota
+	MissingViolations = iota
 
 	// encoding/decoding errors
 	BodyReadError = 30
 	JSONMarshalError = iota
 	JSONUnmarshalError = iota
 
-	// validation errors
+	// validation errors usually result in a 400 error
 	InvalidIPError = 40
 	InvalidReputationError = iota
 	InvalidViolationTypeError = iota
 
-	// missing parameter errors
+	// missing parameter errors usually result in a 400 error
 	MissingIPError = 50
 	MissingReputationError = iota
 	MissingViolationTypeError = iota
@@ -72,12 +72,12 @@ func DescribeErrno(errno Errno) string {
 	case MissingViolationTypeError:
 		return "Error finding violation type in %s: %s"
 
-	case RequestContextMissingDB:
-		return "Could not find database handler in request context."
-	case RequestContextMissingViolations:
-		return "Could not find violation penalties in request context."
-	case RequestContextMissingStatsd:
-		return "Could not find statsdClient in request context."
+	case MissingDB:
+		return "Could not find database."
+	case MissingViolations:
+		return "Could not find violation penalties."
+	case MissingStatsdClient:
+		return "Could not find statsdClient."
 
 	case CWDNotFound:
 		return "Error getting CWD: %s"

--- a/handlers.go
+++ b/handlers.go
@@ -328,17 +328,10 @@ func ReadReputationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if statsdClient == nil {
-		log.WithFields(log.Fields{"errno": RequestContextMissingStatsd}).Infof(DescribeErrno(RequestContextMissingStatsd))
-	}
-
 	entry, err := db.SelectSmallestMatchingSubnet(ip)
 	if err == sql.ErrNoRows {
 		w.WriteHeader(http.StatusNotFound)
 		log.Debugf("No entries found for IP %s", ip)
-		if statsdClient != nil {
-			statsdClient.Incr("misses", nil, 1.0)
-		}
 		return
 	} else if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -350,9 +343,6 @@ func ReadReputationHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.WithFields(log.Fields{"errno": JSONMarshalError}).Warnf(DescribeErrno(JSONMarshalError), "reputation", err)
 		return
-	}
-	if statsdClient != nil {
-		statsdClient.Incr("hits", nil, 1.0)
 	}
 	w.WriteHeader(http.StatusOK)
 	w.Write(json)

--- a/handlers.go
+++ b/handlers.go
@@ -15,7 +15,6 @@ import (
 
 // Context Keys
 const (
-	ctxDBKey = "db"
 	ctxStatsdKey = "statsd"
 	ctxStartTimeKey = "startTime"
 )
@@ -30,13 +29,11 @@ func LoadBalancerHeartbeatHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func HeartbeatHandler(w http.ResponseWriter, req *http.Request) {
-	val := req.Context().Value(ctxDBKey)
-	if val == nil {
+	if db == nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
 		return
 	}
-	db := val.(*DB)
 
 	err := db.Ping()
 	if err != nil {
@@ -153,13 +150,11 @@ func UpsertReputationByViolationHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	val = r.Context().Value(ctxDBKey)
-	if val == nil {
+	if db == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	db := val.(*DB)
 
 	err = db.InsertOrUpdateReputationPenalty(nil, ip, uint(penalty))
 	if _, ok := err.(CheckViolationError); ok {
@@ -203,13 +198,11 @@ func CreateReputationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	val := r.Context().Value(ctxDBKey)
-	if val == nil {
+	if db == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	db := val.(*DB)
 
 	err = db.InsertReputationEntry(nil, entry)
 	if _, ok := err.(CheckViolationError); ok {
@@ -272,13 +265,11 @@ func UpdateReputationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	val := r.Context().Value(ctxDBKey)
-	if val == nil {
+	if db == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	db := val.(*DB)
 
 	err = db.UpdateReputationEntry(nil, entry)
 	if _, ok := err.(CheckViolationError); ok {
@@ -308,13 +299,11 @@ func DeleteReputationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	val := r.Context().Value(ctxDBKey)
-	if val == nil {
+	if db == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	db := val.(*DB)
 
 	err = db.DeleteReputationEntry(nil, ReputationEntry{IP: ip})
 	if err != nil {

--- a/handlers.go
+++ b/handlers.go
@@ -68,21 +68,15 @@ func VersionHandler(w http.ResponseWriter, req *http.Request) {
 
 // Returns a list of known violations for debugging
 func ListViolationsHandler(w http.ResponseWriter, req *http.Request) {
-	if violationPenalties == nil {
+	if violationPenalties == nil || violationPenaltiesJson == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingViolations}).Warnf(DescribeErrno(RequestContextMissingViolations))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	json, err := json.Marshal(violationPenalties)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": JSONMarshalError}).Warnf(DescribeErrno(JSONMarshalError), "violations", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(json)
+	w.Write(violationPenaltiesJson)
 }
 
 // UpsertReputationByViolation takes a JSON body from the http request

--- a/handlers.go
+++ b/handlers.go
@@ -15,7 +15,6 @@ import (
 
 // Context Keys
 const (
-	ctxStatsdKey = "statsd"
 	ctxStartTimeKey = "startTime"
 )
 

--- a/handlers.go
+++ b/handlers.go
@@ -3,7 +3,6 @@ package tigerblood
 import (
 	log "github.com/Sirupsen/logrus"
 	"go.mozilla.org/mozlogrus"
-	"github.com/DataDog/datadog-go/statsd"
 	"database/sql"
 	"fmt"
 	"net/http"
@@ -352,11 +351,7 @@ func ReadReputationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var statsdClient *statsd.Client = nil
-	val := r.Context().Value(ctxStatsdKey)
-	if val != nil {
-		statsdClient = val.(*statsd.Client)
-	} else {
+	if statsdClient == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingStatsd}).Infof(DescribeErrno(RequestContextMissingStatsd))
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -13,11 +13,6 @@ import (
 	"strings"
 )
 
-// Context Keys
-const (
-	ctxStartTimeKey = "startTime"
-)
-
 func init() {
 	mozlogrus.Enable("tigerblood")
 }

--- a/handlers.go
+++ b/handlers.go
@@ -25,7 +25,7 @@ func LoadBalancerHeartbeatHandler(w http.ResponseWriter, req *http.Request) {
 func HeartbeatHandler(w http.ResponseWriter, req *http.Request) {
 	if db == nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
 		return
 	}
 
@@ -64,7 +64,7 @@ func VersionHandler(w http.ResponseWriter, req *http.Request) {
 // Returns a list of known violations for debugging
 func ListViolationsHandler(w http.ResponseWriter, req *http.Request) {
 	if violationPenalties == nil || violationPenaltiesJson == nil {
-		log.WithFields(log.Fields{"errno": RequestContextMissingViolations}).Warnf(DescribeErrno(RequestContextMissingViolations))
+		log.WithFields(log.Fields{"errno": MissingViolations}).Warnf(DescribeErrno(MissingViolations))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -124,7 +124,7 @@ func UpsertReputationByViolationHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if violationPenalties == nil {
-		log.WithFields(log.Fields{"errno": RequestContextMissingViolations}).Warnf(DescribeErrno(RequestContextMissingViolations))
+		log.WithFields(log.Fields{"errno": MissingViolations}).Warnf(DescribeErrno(MissingViolations))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -139,7 +139,7 @@ func UpsertReputationByViolationHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if db == nil {
-		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -187,7 +187,7 @@ func CreateReputationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if db == nil {
-		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -254,7 +254,7 @@ func UpdateReputationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if db == nil {
-		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -288,7 +288,7 @@ func DeleteReputationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if db == nil {
-		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -318,7 +318,7 @@ func ReadReputationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if db == nil {
-		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -16,7 +16,6 @@ import (
 // Context Keys
 const (
 	ctxDBKey = "db"
-	ctxPenaltiesKey = "violationPenalties"
 	ctxStatsdKey = "statsd"
 	ctxStartTimeKey = "startTime"
 )
@@ -73,13 +72,11 @@ func VersionHandler(w http.ResponseWriter, req *http.Request) {
 
 // Returns a list of known violations for debugging
 func ListViolationsHandler(w http.ResponseWriter, req *http.Request) {
-	val := req.Context().Value(ctxPenaltiesKey)
-	if val == nil {
+	if violationPenalties == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingViolations}).Warnf(DescribeErrno(RequestContextMissingViolations))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	violationPenalties := val.(map[string]uint)
 
 	json, err := json.Marshal(violationPenalties)
 	if err != nil {
@@ -141,13 +138,11 @@ func UpsertReputationByViolationHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	val := r.Context().Value(ctxPenaltiesKey)
-	if val == nil {
+	if violationPenalties == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingViolations}).Warnf(DescribeErrno(RequestContextMissingViolations))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	violationPenalties := val.(map[string]uint)
 
 	// lookup violation weight in config map
 	var penalty, ok = violationPenalties[entry.Violation]

--- a/handlers.go
+++ b/handlers.go
@@ -346,16 +346,14 @@ func ReadReputationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	val := r.Context().Value(ctxDBKey)
-	if val == nil {
+	if db == nil {
 		log.WithFields(log.Fields{"errno": RequestContextMissingDB}).Warnf(DescribeErrno(RequestContextMissingDB))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	db := val.(*DB)
 
 	var statsdClient *statsd.Client = nil
-	val = r.Context().Value(ctxStatsdKey)
+	val := r.Context().Value(ctxStatsdKey)
 	if val != nil {
 		statsdClient = val.(*statsd.Client)
 	} else {

--- a/middleware.go
+++ b/middleware.go
@@ -49,27 +49,6 @@ func AddStatsdClient(statsdClient *statsd.Client) Middleware {
 	}
 }
 
-func AddViolations(violationPenalties map[string]uint) Middleware {
-	for violationType, penalty := range violationPenalties {
-		if !(IsValidViolationName(violationType) && IsValidViolationPenalty(uint64(penalty))) {
-			delete(violationPenalties, violationType)
-			if !IsValidViolationName(violationType) {
-				log.Printf("Skipping invalid violation type: %s", violationType)
-			}
-			if !IsValidViolationPenalty(uint64(penalty)) {
-				log.Printf("Skipping invalid violation penalty: %s", penalty)
-			}
-		}
-	}
-
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			h.ServeHTTP(w, addtoContext(r, ctxPenaltiesKey, violationPenalties))
-		})
-	}
-}
-
-
 type ResponseHeader struct {
 	Field string
 	Value string

--- a/middleware.go
+++ b/middleware.go
@@ -33,14 +33,6 @@ func addtoContext(r *http.Request, key string, value interface{}) *http.Request 
 	return r.WithContext(context.WithValue(ctx, key, value))
 }
 
-func AddDB(db *DB) Middleware {
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			h.ServeHTTP(w, addtoContext(r, ctxDBKey, db))
-		})
-	}
-}
-
 func AddStatsdClient(statsdClient *statsd.Client) Middleware {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middleware.go
+++ b/middleware.go
@@ -1,16 +1,8 @@
 package tigerblood
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"go.mozilla.org/mozlogrus"
 	"net/http"
-	"context"
-	"time"
 )
-
-func init() {
-	mozlogrus.Enable("tigerblood")
-}
 
 // Middleware wraps an http.Handler with additional functionality.
 type Middleware func(http.Handler) http.Handler
@@ -24,12 +16,6 @@ func HandleWithMiddleware(h http.Handler, adapters []Middleware) http.Handler {
 		h = adapters[i](h)
 	}
 	return h
-}
-
-// addToContext add the given key value pair to the given request's context
-func addtoContext(r *http.Request, key string, value interface{}) *http.Request {
-	ctx := r.Context()
-	return r.WithContext(context.WithValue(ctx, key, value))
 }
 
 type ResponseHeader struct {
@@ -50,38 +36,6 @@ func SetResponseHeaders() Middleware {
 			for _, header := range DefaultResponseHeaders {
 				w.Header().Add(header.Field, header.Value)
 			}
-			h.ServeHTTP(w, r)
-		})
-	}
-}
-
-func RecordStartTime() Middleware {
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			h.ServeHTTP(w, addtoContext(r, ctxStartTimeKey, time.Now()))
-		})
-	}
-}
-
-func LogRequestDuration(slowRequestCutoff int) Middleware {
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			val := r.Context().Value(ctxStartTimeKey)
-			if val == nil {
-				log.Printf("Could not find startTime in request context.")
-				return
-			}
-			startTime := val.(time.Time)
-
-			if statsdClient != nil {
-				statsdClient.Histogram("request.duration", float64(time.Since(startTime).Nanoseconds())/float64(1e6), nil, 1)
-			}
-			if time.Since(startTime).Nanoseconds() > int64(slowRequestCutoff) {
-				log.WithFields(log.Fields{
-					"processing_time": time.Since(startTime).Nanoseconds(),
-				}).Infof("Slow request completed successfully.")
-			}
-
 			h.ServeHTTP(w, r)
 		})
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -28,7 +28,7 @@ func randViolations(numEntries int) map[string]uint {
 	return violations
 }
 
-func TestAddViolationsMiddlewareSkipsInvalidPenalties(t *testing.T) {
+func TestSetViolationPenaltiesSkipsInvalidPenalties(t *testing.T) {
 	testViolations := map[string]uint{
 		"": 20,
 		"TestViolation:2": 120,

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,34 +1,13 @@
 package tigerblood
 
 import (
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 	"math/rand"
 	"io/ioutil"
 )
-
-
-
-func TestDurationTrackingMiddlewareWithStatsd(t *testing.T) {
-	statsdClient, err := statsd.New("127.0.0.1:39209")
-	assert.Nil(t, err)
-	statsdClient.Namespace = "TestDurationTrackingMiddlewareWithStatsd."
-
-	h := HandleWithMiddleware(NewRouter(), []Middleware{RecordStartTime(), AddStatsdClient(statsdClient), LogRequestDuration(1e7)})
-	req := httptest.NewRequest("GET", "/__version__", nil)
-	recorder := httptest.NewRecorder()
-	h.ServeHTTP(recorder, req)
-	res := recorder.Result()
-
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-
-	// TODO: assert statsd receives data
-}
-
 
 // http://stackoverflow.com/a/22892986
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -49,33 +28,15 @@ func randViolations(numEntries int) map[string]uint {
 	return violations
 }
 
-
-func TestDurationTrackingMiddlewareLogsSlowRequest(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-	testViolations := randViolations(9001)
-	slowRequestToleranceNs := 100
-	h := HandleWithMiddleware(NewRouter(),
-		[]Middleware{RecordStartTime(),
-			AddViolations(testViolations),
-			LogRequestDuration(slowRequestToleranceNs)})
-	start := time.Now()
-
-	req := httptest.NewRequest("GET", "/violations", nil)
-	recorder := httptest.NewRecorder()
-	h.ServeHTTP(recorder, req)
-	res := recorder.Result()
-
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	assert.True(t, time.Since(start).Nanoseconds() > int64(slowRequestToleranceNs))
-}
-
 func TestAddViolationsMiddlewareSkipsInvalidPenalties(t *testing.T) {
 	testViolations := map[string]uint{
 		"": 20,
 		"TestViolation:2": 120,
 	}
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddViolations(testViolations)})
+	SetViolationPenalties(testViolations)
+
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	req := httptest.NewRequest("GET", "/violations", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -88,28 +49,6 @@ func TestAddViolationsMiddlewareSkipsInvalidPenalties(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "{}", string(body))
-}
-
-func TestDurationTrackingMiddlewareWithoutStatsd(t *testing.T) {
-	h := HandleWithMiddleware(NewRouter(), []Middleware{RecordStartTime(), LogRequestDuration(1e7)})
-	req := httptest.NewRequest("GET", "/__version__", nil)
-	recorder := httptest.NewRecorder()
-	h.ServeHTTP(recorder, req)
-	res := recorder.Result()
-
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-}
-
-func TestDurationTrackingMiddlewareWithoutStatsdAndStartTime(t *testing.T) {
-	// should never be configured this way, but also shouldn't explode
-
-	h := HandleWithMiddleware(NewRouter(), []Middleware{LogRequestDuration(1e7)})
-	req := httptest.NewRequest("GET", "/__version__", nil)
-	recorder := httptest.NewRecorder()
-	h.ServeHTTP(recorder, req)
-	res := recorder.Result()
-
-	assert.Equal(t, http.StatusOK, res.StatusCode)
 }
 
 func TestSetResponseHeadersMiddleware(t *testing.T) {

--- a/reputation_test.go
+++ b/reputation_test.go
@@ -204,3 +204,13 @@ func TestDeleteEntry(t *testing.T) {
 	_, err = db.SelectSmallestMatchingSubnet("192.168.0.1")
 	assert.NotNil(t, err)
 }
+
+func TestDeleteEntryNoDB(t *testing.T) {
+	recorder := httptest.ResponseRecorder{}
+
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+
+	SetDB(nil)
+	h.ServeHTTP(&recorder, httptest.NewRequest("DELETE", "/192.168.0.1", nil))
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}

--- a/reputation_test.go
+++ b/reputation_test.go
@@ -17,7 +17,9 @@ func TestReadReputationInvalidIP(t *testing.T) {
 	assert.Nil(t, err)
 	err = db.CreateTables()
 	assert.Nil(t, err)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/2472814.124981275", nil))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
@@ -33,7 +35,9 @@ func TestReadReputationValidIP(t *testing.T) {
 		Reputation: 50,
 	})
 	assert.Nil(t, err)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/127.0.0.1", nil))
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Nil(t, err)
@@ -46,12 +50,15 @@ func TestReadReputationNoEntry(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
+
 	err = db.InsertOrUpdateReputationEntry(nil, ReputationEntry{
 		IP:         "127.0.0.0/8",
 		Reputation: 50,
 	})
 	assert.Nil(t, err)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/255.0.0.1", nil))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	assert.Nil(t, err)
@@ -65,7 +72,8 @@ func TestCreateEntry(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	assert.Equal(t, http.StatusCreated, recorder.Code)
@@ -86,7 +94,9 @@ func TestCreateEntryInvalidIP(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1 -- SELECT(2)", "reputation": 200}`)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Nil(t, err)
@@ -99,7 +109,9 @@ func TestCreateEntryInvalidReputation(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 200}`)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Nil(t, err)
@@ -112,7 +124,9 @@ func TestUpdateEntry(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 25}`)))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
@@ -132,7 +146,9 @@ func TestDeleteEntry(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 	db.emptyReputationTable()
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	recorder = httptest.ResponseRecorder{}
 	h.ServeHTTP(&recorder, httptest.NewRequest("DELETE", "/192.168.0.1", nil))

--- a/reputation_test.go
+++ b/reputation_test.go
@@ -87,6 +87,15 @@ func TestCreateEntry(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, recorder.Code)
 }
 
+func TestCreateEntryNoDB(t *testing.T) {
+	recorder := httptest.ResponseRecorder{}
+	SetDB(nil)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+
+	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}
+
 func TestCreateEntryInvalidJson(t *testing.T) {
 	recorder := httptest.ResponseRecorder{}
 	dsn, found := os.LookupEnv("TIGERBLOOD_DSN")

--- a/reputation_test.go
+++ b/reputation_test.go
@@ -87,6 +87,21 @@ func TestCreateEntry(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, recorder.Code)
 }
 
+func TestCreateEntryInvalidJson(t *testing.T) {
+	recorder := httptest.ResponseRecorder{}
+	dsn, found := os.LookupEnv("TIGERBLOOD_DSN")
+	assert.True(t, found)
+	db, err := NewDB(dsn)
+	assert.Nil(t, err)
+	db.emptyReputationTable()
+
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1`)))
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Nil(t, err)
+}
+
 func TestCreateEntryInvalidIP(t *testing.T) {
 	recorder := httptest.ResponseRecorder{}
 	dsn, found := os.LookupEnv("TIGERBLOOD_DSN")

--- a/router.go
+++ b/router.go
@@ -18,7 +18,9 @@ func AttachProfiler(router *mux.Router) {
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 
-	AttachProfiler(router)
+	if useProfileHandlers {
+		AttachProfiler(router)
+	}
 
 	for _, route := range routes {
 		var handler http.Handler

--- a/router.go
+++ b/router.go
@@ -3,10 +3,22 @@ package tigerblood
 import (
 	"github.com/gorilla/mux"
 	"net/http"
+	"net/http/pprof"
 )
+
+
+func AttachProfiler(router *mux.Router) {
+	// Register pprof handlers
+	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+}
 
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
+
+	AttachProfiler(router)
 
 	for _, route := range routes {
 		var handler http.Handler
@@ -36,6 +48,10 @@ var UnauthedRoutes = map[string]bool{
 	"/__lbheartbeat__": true,
 	"/__heartbeat__": true,
 	"/__version__": true,
+	"/debug/pprof/": true,
+	"/debug/pprof/cmdline": true,
+	"/debug/pprof/profile": true,
+	"/debug/pprof/symbol": true,
 }
 
 var routes = Routes{

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -11,6 +11,7 @@ var db *DB = nil
 var statsdClient *statsd.Client = nil
 var violationPenalties map[string]uint = nil
 var violationPenaltiesJson []byte = nil
+var useProfileHandlers = false
 
 func init() {
 	mozlogrus.Enable("tigerblood")
@@ -18,6 +19,10 @@ func init() {
 
 func SetDB(newDb *DB) {
 	db = newDb
+}
+
+func SetProfileHandlers(profileHandlers bool) {
+	useProfileHandlers = profileHandlers
 }
 
 func SetStatsdClient(newClient *statsd.Client) {

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -6,6 +6,7 @@ import (
 
 var db *DB = nil
 var statsdClient *statsd.Client = nil
+var violationPenalties map[string]uint = nil
 
 func SetDB(newDb *DB) {
 	db = newDb
@@ -13,4 +14,8 @@ func SetDB(newDb *DB) {
 
 func SetStatsdClient(newClient *statsd.Client) {
 	statsdClient = newClient
+}
+
+func SetViolationPenalties(newPenalties map[string]uint) {
+	violationPenalties = newPenalties
 }

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -1,1 +1,7 @@
 package tigerblood
+
+var db *DB = nil
+
+func SetDB(newDb *DB) {
+	db = newDb
+}

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -2,11 +2,19 @@ package tigerblood
 
 import (
 	"github.com/DataDog/datadog-go/statsd"
+	"encoding/json"
+	log "github.com/Sirupsen/logrus"
+	"go.mozilla.org/mozlogrus"
 )
 
 var db *DB = nil
 var statsdClient *statsd.Client = nil
 var violationPenalties map[string]uint = nil
+var violationPenaltiesJson []byte = nil
+
+func init() {
+	mozlogrus.Enable("tigerblood")
+}
 
 func SetDB(newDb *DB) {
 	db = newDb
@@ -18,4 +26,11 @@ func SetStatsdClient(newClient *statsd.Client) {
 
 func SetViolationPenalties(newPenalties map[string]uint) {
 	violationPenalties = newPenalties
+
+	// set violationPenaltiesJson
+	json, err := json.Marshal(violationPenalties)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": JSONMarshalError}).Warnf(DescribeErrno(JSONMarshalError), "violations", err)
+	}
+	violationPenaltiesJson = json
 }

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -30,6 +30,18 @@ func SetStatsdClient(newClient *statsd.Client) {
 }
 
 func SetViolationPenalties(newPenalties map[string]uint) {
+	for violationType, penalty := range newPenalties {
+		if !(IsValidViolationName(violationType) && IsValidViolationPenalty(uint64(penalty))) {
+			delete(newPenalties, violationType)
+			if !IsValidViolationName(violationType) {
+				log.Printf("Skipping invalid violation type: %s", violationType)
+			}
+			if !IsValidViolationPenalty(uint64(penalty)) {
+				log.Printf("Skipping invalid violation penalty: %s", penalty)
+			}
+		}
+ 	}
+
 	violationPenalties = newPenalties
 
 	// set violationPenaltiesJson

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -1,7 +1,16 @@
 package tigerblood
 
+import (
+	"github.com/DataDog/datadog-go/statsd"
+)
+
 var db *DB = nil
+var statsdClient *statsd.Client = nil
 
 func SetDB(newDb *DB) {
 	db = newDb
+}
+
+func SetStatsdClient(newClient *statsd.Client) {
+	statsdClient = newClient
 }

--- a/unauthed_test.go
+++ b/unauthed_test.go
@@ -55,3 +55,27 @@ func TestVersionHandler(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 }
+
+func TestDebugRoutesWhenProfileHandlersEnabled(t *testing.T) {
+	SetProfileHandlers(true)
+
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	res := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestDebugRoutesWhenProfileHandlersDisabled(t *testing.T) {
+	SetProfileHandlers(false)
+
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	res := recorder.Result()
+
+	assert.Equal(t, http.StatusMovedPermanently, res.StatusCode)
+}

--- a/unauthed_test.go
+++ b/unauthed_test.go
@@ -24,7 +24,8 @@ func TestHeartbeatHandler(t *testing.T) {
 	db, err := NewDB(dsn)
 	assert.Nil(t, err)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db)})
+	SetDB(db)
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	req := httptest.NewRequest("GET", "/__heartbeat__", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -34,6 +35,8 @@ func TestHeartbeatHandler(t *testing.T) {
 }
 
 func TestHeartbeatHandlerWithoutDB(t *testing.T) {
+	SetDB(nil)
+
 	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	req := httptest.NewRequest("GET", "/__heartbeat__", nil)
 	recorder := httptest.NewRecorder()

--- a/violation_test.go
+++ b/violation_test.go
@@ -16,7 +16,9 @@ func TestListViolations(t *testing.T) {
 		"TestViolation:2": 20,
 	}
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddViolations(testViolations)})
+	SetViolationPenalties(testViolations)
+
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	req := httptest.NewRequest("GET", "/violations", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -32,6 +34,8 @@ func TestListViolations(t *testing.T) {
 }
 
 func TestListViolationsMissingViolationsMiddleware(t *testing.T) {
+	SetViolationPenalties(nil)
+
 	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 	req := httptest.NewRequest("GET", "/violations", nil)
 	recorder := httptest.NewRecorder()
@@ -53,7 +57,10 @@ func TestInsertReputationByViolation(t *testing.T) {
 		"Test:Violation": 90,
 	}
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddDB(db), AddViolations(testViolations)})
+	SetDB(db)
+	SetViolationPenalties(testViolations)
+
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 
 	t.Run("known", func (t *testing.T) {
 		// known violation type is subtracted from default reputation
@@ -95,7 +102,11 @@ func TestInsertReputationByViolationRequiresDB(t *testing.T) {
 	testViolations := map[string]uint{
 		"TestViolation": 90,
 	}
-	h := HandleWithMiddleware(NewRouter(), []Middleware{AddViolations(testViolations)})
+	SetViolationPenalties(testViolations)
+
+	SetDB(nil)
+
+	h := HandleWithMiddleware(NewRouter(), []Middleware{})
 
 	recorder := httptest.ResponseRecorder{}
 	h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/violations/192.168.0.1", strings.NewReader(`{"Violation": "TestViolation"}`)))


### PR DESCRIPTION
Changes:

* Add `TIGERBLOOD_PROFILE` env var flag to disable and enable unauthed pprof debug endpoints
* Use globals instead of middleware for db, statsdclient, and violations (these values are not request-scoped and don't need to be in a `Context`)
* Compute violations JSON when violations set
* Remove statsd hit and miss tracking since we can compute there from 404 or 200 status codes in the access logs
* Remove response timing middleware since we can track latency at the ELB level
* Increase max idle db connections (from default of 2) and lifetime
* Add config params for max idle db connections and max lifetime

CPU cumulative time profile with [go-torch](https://github.com/uber/go-torch) (per mostlygeek's recommendation) on laptop (specifically `go-torch --seconds 30 http://127.0.0.1:8080/debug/pprof/profile`):

61d6777d594d0ffa60b656463262530b390f3666 (first commit on this branch enabling pprof):

<img width="946" alt="screen shot 2017-03-28 at 11 09 26 am" src="https://cloud.githubusercontent.com/assets/226605/24412660/110f8250-13a7-11e7-8022-5f597f4eba5c.png">

read-only load at 50 req/s for 10 test IPs settles down to roughly min: '5.99', median: '17.33', max: '56.78' ms.

43001b6f62513ab0a8d1ddfc26deac56df9056ff:

<img width="944" alt="screen shot 2017-03-28 at 11 16 00 am" src="https://cloud.githubusercontent.com/assets/226605/24412959/f850f1b2-13a7-11e7-97a8-e60ef1859914.png">

same load roughly min: '5.71', median: '10.61', max: '15.53' ms.