### PR TITLE
Go Faster?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,16 @@ rm-db:
 test:
 	TIGERBLOOD_DSN="user=tigerblood dbname=tigerblood sslmode=disable" go test
 
+torch-cpu:
+	go-torch --seconds 30 http://127.0.0.1:8080/debug/pprof/profile && open torch.svg
+
+mem-objs:
+	go tool pprof --alloc_objects http://127.0.0.1:8080/debug/pprof/heap
+
+build-gc-opts:  # log gc optimizations like inlined funcs
+	rm -f gc-build.out
+	go build -v -gcflags=-m &> gc-build.out
+
 coverage:
 	TIGERBLOOD_DSN="user=tigerblood dbname=tigerblood sslmode=disable" go test -coverprofile=coverage.txt -covermode=atomic
 	sed "s|_$$(pwd)/|./|g" coverage.txt > rel-coverage.txt

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -158,11 +158,8 @@ func main() {
 	loadConfig()
 	printConfig()
 
-	var middleware []tigerblood.Middleware
-
 	if viper.GetBool("HAWK") {
 		tigerblood.SetHawkCreds(loadCredentials())
-		middleware = append(middleware, tigerblood.RequireHawkAuth)
 	}
 
 	tigerblood.SetProfileHandlers(viper.GetBool("PROFILE"))
@@ -177,11 +174,7 @@ func main() {
 
 	tigerblood.SetViolationPenalties(loadViolationPenalties())
 
-	middleware = append(middleware, tigerblood.SetResponseHeaders)
-
 	log.Printf("Listening on %s", viper.GetString("BIND_ADDR"))
-	err := http.ListenAndServe(
-		viper.GetString("BIND_ADDR"),
-		tigerblood.HandleWithMiddleware(tigerblood.NewRouter(), middleware))
+	err := http.ListenAndServe(viper.GetString("BIND_ADDR"), tigerblood.NewRouter())
 	log.Fatal(err)
 }

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -161,7 +161,8 @@ func main() {
 	var middleware []tigerblood.Middleware
 
 	if viper.GetBool("HAWK") {
-		middleware = append(middleware, tigerblood.RequireHawkAuth(loadCredentials()))
+		tigerblood.SetHawkCreds(loadCredentials())
+		middleware = append(middleware, tigerblood.RequireHawkAuth)
 	}
 
 	tigerblood.SetProfileHandlers(viper.GetBool("PROFILE"))

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -176,7 +176,7 @@ func main() {
 
 	tigerblood.SetViolationPenalties(loadViolationPenalties())
 
-	middleware = append(middleware, tigerblood.SetResponseHeaders())
+	middleware = append(middleware, tigerblood.SetResponseHeaders)
 
 	log.Printf("Listening on %s", viper.GetString("BIND_ADDR"))
 	err := http.ListenAndServe(

--- a/db.go
+++ b/db.go
@@ -80,7 +80,7 @@ func NewDB(dsn string) (*DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Could not create tables: %s", err)
 	}
-	reputationSelectStmt, err := db.Prepare("SELECT ip, reputation FROM reputation WHERE ip >>= $1 ORDER BY @ ip LIMIT 1;")
+	reputationSelectStmt, err := db.Prepare("SELECT ip, reputation FROM reputation WHERE ip >>= $1 LIMIT 1;")
 	if err != nil {
 		return nil, fmt.Errorf("Could not create prepared statement: %s", err)
 	}

--- a/db.go
+++ b/db.go
@@ -80,7 +80,7 @@ func NewDB(dsn string) (*DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Could not create tables: %s", err)
 	}
-	reputationSelectStmt, err := db.Prepare("SELECT ip, reputation FROM reputation WHERE ip >>= $1 LIMIT 1;")
+	reputationSelectStmt, err := db.Prepare("SELECT ip, reputation FROM reputation WHERE ip >>= $1 ORDER BY @ ip LIMIT 1;")
 	if err != nil {
 		return nil, fmt.Errorf("Could not create prepared statement: %s", err)
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -3,14 +3,10 @@ package tigerblood
 import (
 	log "github.com/Sirupsen/logrus"
 	"go.mozilla.org/mozlogrus"
-	"database/sql"
 	"fmt"
 	"net/http"
-	"io/ioutil"
-	"encoding/json"
 	"os"
 	"path"
-	"strings"
 )
 
 func init() {
@@ -18,11 +14,21 @@ func init() {
 }
 
 func LoadBalancerHeartbeatHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 	return
 }
 
 func HeartbeatHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
 	if db == nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
@@ -38,6 +44,11 @@ func HeartbeatHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func VersionHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
 	dir, err := os.Getwd()
 	if err != nil {
 		log.WithFields(log.Fields{"errno": CWDNotFound}).Warnf(DescribeErrno(CWDNotFound), err)
@@ -59,286 +70,4 @@ func VersionHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	http.ServeContent(w, req, "__version__", stat.ModTime(), f)
-}
-
-// Returns a list of known violations for debugging
-func ListViolationsHandler(w http.ResponseWriter, req *http.Request) {
-	if violationPenalties == nil || violationPenaltiesJson == nil {
-		log.WithFields(log.Fields{"errno": MissingViolations}).Warnf(DescribeErrno(MissingViolations))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write(violationPenaltiesJson)
-}
-
-// UpsertReputationByViolation takes a JSON body from the http request
-// and upserts the reputation entry on the database to the reputation
-// given in reputation violation.  The HTTP requests path has to
-// contain the IP to be updated, in CIDR notation. For example:
-// {"Violation": "password-reset-rate-limit-exceeded"}
-func UpsertReputationByViolationHandler(w http.ResponseWriter, r *http.Request) {
-	splitPath := strings.Split(r.URL.Path, "/")
-	if len(splitPath) != 3 {
-		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), r.URL.Path)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	ip, err := IPAddressFromHTTPPath("/" + splitPath[2])
-
-	if err != nil {
-		log.WithFields(log.Fields{"errno": MissingIPError}).Infof(DescribeErrno(MissingIPError), r.URL.Path, err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if !IsValidReputationCIDROrIP(ip) {
-		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), splitPath[2])
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": BodyReadError}).Warnf(DescribeErrno(BodyReadError))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	type ViolationBody struct {
-		Violation string
-	}
-	var entry ViolationBody
-	err = json.Unmarshal(body, &entry)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": JSONUnmarshalError}).Warnf(DescribeErrno(JSONUnmarshalError), err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if !IsValidViolationName(entry.Violation) {
-		log.WithFields(log.Fields{"errno": InvalidViolationTypeError}).Infof(DescribeErrno(InvalidViolationTypeError), entry.Violation)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if violationPenalties == nil {
-		log.WithFields(log.Fields{"errno": MissingViolations}).Warnf(DescribeErrno(MissingViolations))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	// lookup violation weight in config map
-	var penalty, ok = violationPenalties[entry.Violation]
-	if !ok {
-		log.WithFields(log.Fields{"errno": MissingViolationTypeError}).Infof("Could not find violation type: %s", entry.Violation)
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Violation type not found."))
-		return
-	}
-
-	if db == nil {
-		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	err = db.InsertOrUpdateReputationPenalty(nil, ip, uint(penalty))
-	if _, ok := err.(CheckViolationError); ok {
-		log.WithFields(log.Fields{"errno": InvalidReputationError}).Warnf("Reputation is outside of valid range [0-100]")
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Reputation is outside of valid range [0-100]"))
-	} else if err != nil {
-		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not update reputation entry by violation: %s", err)
-		w.WriteHeader(http.StatusInternalServerError)
-	} else if err == nil {
-		log.Debugf("Updated reputation for %s due to %d", ip, penalty)
-		w.WriteHeader(http.StatusNoContent)
-	}
-}
-
-// CreateReputation takes a JSON formatted IP reputation entry from
-// the http request and inserts it to the database.
-func CreateReputationHandler(w http.ResponseWriter, r *http.Request) {
-	var entry ReputationEntry
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		log.WithFields(log.Fields{"errno": BodyReadError}).Warnf(DescribeErrno(BodyReadError))
-		return
-	}
-	err = json.Unmarshal(body, &entry)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": JSONUnmarshalError}).Warnf(DescribeErrno(JSONUnmarshalError), err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if !IsValidReputationEntry(entry) {
-		if !IsValidReputationCIDROrIP(entry.IP) {
-			log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), entry.IP)
-		}
-		if !IsValidReputation(entry.Reputation) {
-			log.WithFields(log.Fields{"errno": InvalidReputationError}).Infof(DescribeErrno(InvalidReputationError), entry.Reputation)
-		}
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if db == nil {
-		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	err = db.InsertReputationEntry(nil, entry)
-	if _, ok := err.(CheckViolationError); ok {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Reputation is outside of valid range [0-100]"))
-	} else if _, ok := err.(DuplicateKeyError); ok {
-		w.WriteHeader(http.StatusConflict)
-		w.Write([]byte("Reputation is already set for that IP."))
-	} else if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-
-	if err != nil {
-		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not insert reputation entry: %s", err)
-		return
-	}
-	w.WriteHeader(http.StatusCreated)
-}
-
-
-// UpdateReputation takes a JSON body from the http request and updates that reputation entry on the database.
-// The HTTP requests path has to contain the IP to be updated, in CIDR notation. The body can contain the IP address, or it can be omitted. For example:
-// {"Reputation": 50} or {"Reputation": 50, "IP":, "192.168.0.1"}. The IP in the JSON body will be ignored.
-func UpdateReputationHandler(w http.ResponseWriter, r *http.Request) {
-	ip, err := IPAddressFromHTTPPath(r.URL.Path)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": MissingIPError}).Infof(DescribeErrno(MissingIPError), r.URL.Path, err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	if !IsValidReputationCIDROrIP(ip) {
-		w.WriteHeader(http.StatusBadRequest)
-		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), ip)
-		return
-	}
-
-	var entry ReputationEntry
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": BodyReadError}).Warnf(DescribeErrno(BodyReadError))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	err = json.Unmarshal(body, &entry)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": JSONUnmarshalError}).Warnf(DescribeErrno(JSONUnmarshalError), err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	entry.IP = ip
-
-	if !IsValidReputationEntry(entry) {
-		if !IsValidReputationCIDROrIP(entry.IP) {
-			log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), entry.IP)
-		}
-		if !IsValidReputation(entry.Reputation) {
-			log.WithFields(log.Fields{"errno": InvalidReputationError}).Infof(DescribeErrno(InvalidReputationError), entry.Reputation)
-		}
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if db == nil {
-		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	err = db.UpdateReputationEntry(nil, entry)
-	if _, ok := err.(CheckViolationError); ok {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("Reputation is outside of valid range [0-100]"))
-	} else if err == ErrNoRowsAffected {
-		w.WriteHeader(http.StatusNotFound)
-	} else if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not update reputation entry: %s", err)
-	} else if err == nil {
-		w.WriteHeader(http.StatusOK)
-	}
-}
-
-// DeleteReputation deletes an entry based on the IP address provided on the path
-func DeleteReputationHandler(w http.ResponseWriter, r *http.Request) {
-	ip, err := IPAddressFromHTTPPath(r.URL.Path)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": MissingIPError}).Infof(DescribeErrno(MissingIPError), r.URL.Path, err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	if !IsValidReputationCIDROrIP(ip) {
-		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), ip)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if db == nil {
-		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	err = db.DeleteReputationEntry(nil, ReputationEntry{IP: ip})
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not delete reputation entry: %s", err)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
-}
-
-
-// ReadReputation returns a JSON-formatted reputation entry from the database.
-func ReadReputationHandler(w http.ResponseWriter, r *http.Request) {
-	ip, err := IPAddressFromHTTPPath(r.URL.Path)
-	if err != nil {
-		log.WithFields(log.Fields{"errno": MissingIPError}).Infof(DescribeErrno(MissingIPError), r.URL.Path, err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	if !IsValidReputationCIDROrIP(ip) {
-		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), ip)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if db == nil {
-		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	entry, err := db.SelectSmallestMatchingSubnet(ip)
-	if err == sql.ErrNoRows {
-		w.WriteHeader(http.StatusNotFound)
-		log.Debugf("No entries found for IP %s", ip)
-		return
-	} else if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not get reputation entry: %s", err)
-		return
-	}
-	json, err := json.Marshal(entry)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		log.WithFields(log.Fields{"errno": JSONMarshalError}).Warnf(DescribeErrno(JSONMarshalError), "reputation", err)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
-	w.Write(json)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -14,6 +14,8 @@ func init() {
 }
 
 func LoadBalancerHeartbeatHandler(w http.ResponseWriter, req *http.Request) {
+	SetResponseHeaders(w)
+
 	if req.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -24,6 +26,8 @@ func LoadBalancerHeartbeatHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func HeartbeatHandler(w http.ResponseWriter, req *http.Request) {
+	SetResponseHeaders(w)
+
 	if req.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -44,6 +48,8 @@ func HeartbeatHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func VersionHandler(w http.ResponseWriter, req *http.Request) {
+	SetResponseHeaders(w)
+
 	if req.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/hawk.go
+++ b/hawk.go
@@ -78,7 +78,7 @@ func RequireHawkAuth(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	// Validate the header MAC an skew
+	// Validate the header MAC and skew
 	validationError := auth.Valid()
 	if validationError != nil {
 		log.WithFields(log.Fields{"errno": HawkValidationError}).Warnf("hawk validation error: %s", validationError)

--- a/hawk.go
+++ b/hawk.go
@@ -43,76 +43,72 @@ func NewHawkData(secrets map[string]string) *HawkData {
 	}
 }
 
-func RequireHawkAuth(credentials map[string]string) Middleware {
-	m := NewHawkData(credentials)
-
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if _, ok := UnauthedRoutes[r.URL.Path]; ok {
-				// Authentication not required, continue
-				log.Debugf("Skipping auth for route: %s", r.URL.Path)
-				h.ServeHTTP(w, r)
-				return
-			}
-
-			// Validate the Hawk header format and credentials
-			auth, err := hawk.NewAuthFromRequest(r, m.lookupCredentials, m.lookupNonce)
-			if err != nil {
-				switch err.(type) {
-				case hawk.AuthFormatError:
-					log.WithFields(log.Fields{"errno": HawkAuthFormatError}).Warn(err)
-				case *hawk.CredentialError:
-				 	log.WithFields(log.Fields{"errno": HawkCredError}).Warn(err)
-				case hawk.AuthError: {
-					switch err.(hawk.AuthError) {
-					case hawk.ErrNoAuth:
-						log.WithFields(log.Fields{"errno": HawkErrNoAuth}).Warn(err)
-					case hawk.ErrReplay:
-						log.WithFields(log.Fields{"errno": HawkReplayError}).Warn(err)
-					}
-				}
-				default:
-					log.WithFields(log.Fields{"errno": HawkOtherAuthError}).Warnf("other hawk auth error: %s", err)
-				}
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-
-			// Validate the header MAC an skew
-			validationError := auth.Valid()
-			if validationError != nil {
-				log.WithFields(log.Fields{"errno": HawkValidationError}).Warnf("hawk validation error: %s", validationError)
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-
-			// Validate the payload hash of the request Content-Type and body
-			// assuming bodies will fit in memory always validate the body
-			contentType := r.Header.Get("Content-Type")
-			if r.Method != "GET" && r.Method != "DELETE" && contentType == "" {
-				log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warn("hawk: missing content-type")
-			}
-
-			buf, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				log.WithFields(log.Fields{"errno": HawkReadBodyError}).Warnf("hawk: error reading body %s", err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-
-			r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
-			hash := auth.PayloadHash(contentType)
-			io.Copy(hash, ioutil.NopCloser(bytes.NewBuffer(buf)))
-			if !auth.ValidHash(hash) {
-				log.WithFields(log.Fields{"errno": HawkInvalidBodyHash}).Warnf("hawk: invalid payload hash")
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-
-			// Authentication successful, continue
+func RequireHawkAuth(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := UnauthedRoutes[r.URL.Path]; ok {
+			// Authentication not required, continue
+			log.Debugf("Skipping auth for route: %s", r.URL.Path)
 			h.ServeHTTP(w, r)
-		})
-	}
+			return
+		}
+
+		// Validate the Hawk header format and credentials
+		auth, err := hawk.NewAuthFromRequest(r, hawkData.lookupCredentials, hawkData.lookupNonce)
+		if err != nil {
+			switch err.(type) {
+			case hawk.AuthFormatError:
+				log.WithFields(log.Fields{"errno": HawkAuthFormatError}).Warn(err)
+			case *hawk.CredentialError:
+				log.WithFields(log.Fields{"errno": HawkCredError}).Warn(err)
+			case hawk.AuthError: {
+				switch err.(hawk.AuthError) {
+				case hawk.ErrNoAuth:
+					log.WithFields(log.Fields{"errno": HawkErrNoAuth}).Warn(err)
+				case hawk.ErrReplay:
+					log.WithFields(log.Fields{"errno": HawkReplayError}).Warn(err)
+				}
+			}
+			default:
+				log.WithFields(log.Fields{"errno": HawkOtherAuthError}).Warnf("other hawk auth error: %s", err)
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Validate the header MAC an skew
+		validationError := auth.Valid()
+		if validationError != nil {
+			log.WithFields(log.Fields{"errno": HawkValidationError}).Warnf("hawk validation error: %s", validationError)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Validate the payload hash of the request Content-Type and body
+		// assuming bodies will fit in memory always validate the body
+		contentType := r.Header.Get("Content-Type")
+		if r.Method != "GET" && r.Method != "DELETE" && contentType == "" {
+			log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warn("hawk: missing content-type")
+		}
+
+		buf, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.WithFields(log.Fields{"errno": HawkReadBodyError}).Warnf("hawk: error reading body %s", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+		hash := auth.PayloadHash(contentType)
+		io.Copy(hash, ioutil.NopCloser(bytes.NewBuffer(buf)))
+		if !auth.ValidHash(hash) {
+			log.WithFields(log.Fields{"errno": HawkInvalidBodyHash}).Warnf("hawk: invalid payload hash")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Authentication successful, continue
+		h.ServeHTTP(w, r)
+	})
 }
 
 func (h *HawkData) rotate() {

--- a/hawk.go
+++ b/hawk.go
@@ -43,72 +43,74 @@ func NewHawkData(secrets map[string]string) *HawkData {
 	}
 }
 
-func RequireHawkAuth(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if _, ok := UnauthedRoutes[r.URL.Path]; ok {
-			// Authentication not required, continue
-			log.Debugf("Skipping auth for route: %s", r.URL.Path)
-			h.ServeHTTP(w, r)
-			return
-		}
+func RequireHawkAuth(w http.ResponseWriter, r *http.Request) error {
+	if hawkData == nil {
+		// Auth disabled
+		return nil
+	}
 
-		// Validate the Hawk header format and credentials
-		auth, err := hawk.NewAuthFromRequest(r, hawkData.lookupCredentials, hawkData.lookupNonce)
-		if err != nil {
-			switch err.(type) {
-			case hawk.AuthFormatError:
-				log.WithFields(log.Fields{"errno": HawkAuthFormatError}).Warn(err)
-			case *hawk.CredentialError:
-				log.WithFields(log.Fields{"errno": HawkCredError}).Warn(err)
-			case hawk.AuthError: {
-				switch err.(hawk.AuthError) {
-				case hawk.ErrNoAuth:
-					log.WithFields(log.Fields{"errno": HawkErrNoAuth}).Warn(err)
-				case hawk.ErrReplay:
-					log.WithFields(log.Fields{"errno": HawkReplayError}).Warn(err)
-				}
+	if _, ok := UnauthedRoutes[r.URL.Path]; ok {
+		// Authentication not required, continue
+		log.Debugf("Skipping auth for route: %s", r.URL.Path)
+		return nil
+	}
+
+	// Validate the Hawk header format and credentials
+	auth, err := hawk.NewAuthFromRequest(r, hawkData.lookupCredentials, hawkData.lookupNonce)
+	if err != nil {
+		switch err.(type) {
+		case hawk.AuthFormatError:
+			log.WithFields(log.Fields{"errno": HawkAuthFormatError}).Warn(err)
+		case *hawk.CredentialError:
+			log.WithFields(log.Fields{"errno": HawkCredError}).Warn(err)
+		case hawk.AuthError: {
+			switch err.(hawk.AuthError) {
+			case hawk.ErrNoAuth:
+				log.WithFields(log.Fields{"errno": HawkErrNoAuth}).Warn(err)
+			case hawk.ErrReplay:
+				log.WithFields(log.Fields{"errno": HawkReplayError}).Warn(err)
 			}
-			default:
-				log.WithFields(log.Fields{"errno": HawkOtherAuthError}).Warnf("other hawk auth error: %s", err)
-			}
-			w.WriteHeader(http.StatusUnauthorized)
-			return
 		}
-
-		// Validate the header MAC an skew
-		validationError := auth.Valid()
-		if validationError != nil {
-			log.WithFields(log.Fields{"errno": HawkValidationError}).Warnf("hawk validation error: %s", validationError)
-			w.WriteHeader(http.StatusUnauthorized)
-			return
+		default:
+			log.WithFields(log.Fields{"errno": HawkOtherAuthError}).Warnf("other hawk auth error: %s", err)
 		}
+		w.WriteHeader(http.StatusUnauthorized)
+		return err
+	}
 
-		// Validate the payload hash of the request Content-Type and body
-		// assuming bodies will fit in memory always validate the body
-		contentType := r.Header.Get("Content-Type")
-		if r.Method != "GET" && r.Method != "DELETE" && contentType == "" {
-			log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warn("hawk: missing content-type")
-		}
+	// Validate the header MAC an skew
+	validationError := auth.Valid()
+	if validationError != nil {
+		log.WithFields(log.Fields{"errno": HawkValidationError}).Warnf("hawk validation error: %s", validationError)
+		w.WriteHeader(http.StatusUnauthorized)
+		return validationError
+	}
 
-		buf, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			log.WithFields(log.Fields{"errno": HawkReadBodyError}).Warnf("hawk: error reading body %s", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+	// Validate the payload hash of the request Content-Type and body
+	// assuming bodies will fit in memory always validate the body
+	contentType := r.Header.Get("Content-Type")
+	if r.Method != "GET" && r.Method != "DELETE" && contentType == "" {
+		log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warn("hawk: missing content-type")
+	}
 
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
-		hash := auth.PayloadHash(contentType)
-		io.Copy(hash, ioutil.NopCloser(bytes.NewBuffer(buf)))
-		if !auth.ValidHash(hash) {
-			log.WithFields(log.Fields{"errno": HawkInvalidBodyHash}).Warnf("hawk: invalid payload hash")
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
+	buf, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": HawkReadBodyError}).Warnf("hawk: error reading body %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return err
+	}
 
-		// Authentication successful, continue
-		h.ServeHTTP(w, r)
-	})
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+	hash := auth.PayloadHash(contentType)
+	io.Copy(hash, ioutil.NopCloser(bytes.NewBuffer(buf)))
+	if !auth.ValidHash(hash) {
+		log.WithFields(log.Fields{"errno": HawkInvalidBodyHash}).Warnf("hawk: invalid payload hash")
+		w.WriteHeader(http.StatusUnauthorized)
+		return err
+	}
+
+	// Authentication successful, continue
+	return nil
 }
 
 func (h *HawkData) rotate() {

--- a/hawk_test.go
+++ b/hawk_test.go
@@ -23,7 +23,8 @@ func TestMissingAuthorization(t *testing.T) {
 	assert.Nil(t, err)
 	recorder := httptest.NewRecorder()
 	credentials := make(map[string]string)
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCreds(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -34,7 +35,8 @@ func TestInvalidAuthorization(t *testing.T) {
 	req.Header.Set("Authorization", "Hawk This is clearly not a hawk header")
 	recorder := httptest.NewRecorder()
 	credentials := make(map[string]string)
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCreds(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -56,7 +58,8 @@ func TestInvalidPayload(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCreds(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -79,7 +82,8 @@ func TestValidPayload(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCreds(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }
@@ -103,7 +107,8 @@ func TestValidPayloadNoContentType(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCreds(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }
@@ -115,7 +120,8 @@ func TestExpiration(t *testing.T) {
 	req.Header.Set("Authorization", `Hawk id="fxa", mac="zcMu1EMcdseQ0J/LInTt73gHp3EiygoZnAC7KybGJBQ=", ts="1473887198", nonce="deYFZM4Z", hash="7wQDpR3QDtZYCfOpvQTEpR8cNz1dCX3sar9RLx5CmWk="`)
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCreds(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -138,7 +144,8 @@ func TestReplayProtection(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCreds(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	recorder = httptest.NewRecorder()
@@ -162,7 +169,8 @@ func TestLoadbalancerEndpointsUnauthed(t *testing.T) {
 		assert.Nil(t, err)
 		recorder := httptest.NewRecorder()
 		credentials := map[string]string{"fxa": "foobar"}
-		handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+		SetHawkCreds(credentials)
+		handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 		handler.ServeHTTP(recorder, req)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 	}
@@ -185,7 +193,8 @@ func TestMissingCredentialsReturns401(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"notFxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCreds(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }

--- a/middleware.go
+++ b/middleware.go
@@ -4,20 +4,6 @@ import (
 	"net/http"
 )
 
-// Middleware wraps an http.Handler with additional functionality.
-type Middleware func(http.Handler) http.Handler
-
-// Run the request through all middleware
-func HandleWithMiddleware(h http.Handler, adapters []Middleware) http.Handler {
-	// To make the middleware run in the order in which they are specified,
-	// we reverse through them in the Middleware function, rather than just
-	// ranging over them
-	for i := len(adapters) - 1; i >= 0; i-- {
-		h = adapters[i](h)
-	}
-	return h
-}
-
 type ResponseHeader struct {
 	Field string
 	Value string
@@ -30,11 +16,8 @@ var DefaultResponseHeaders = []ResponseHeader{
 	ResponseHeader{"X-Content-Type-Options", "nosniff"},
 }
 
-func SetResponseHeaders(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, header := range DefaultResponseHeaders {
-			w.Header().Add(header.Field, header.Value)
-		}
-		h.ServeHTTP(w, r)
-	})
+func SetResponseHeaders(w http.ResponseWriter) {
+	for _, header := range DefaultResponseHeaders {
+		w.Header().Add(header.Field, header.Value)
+	}
 }

--- a/middleware.go
+++ b/middleware.go
@@ -30,13 +30,11 @@ var DefaultResponseHeaders = []ResponseHeader{
 	ResponseHeader{"X-Content-Type-Options", "nosniff"},
 }
 
-func SetResponseHeaders() Middleware {
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			for _, header := range DefaultResponseHeaders {
-				w.Header().Add(header.Field, header.Value)
-			}
-			h.ServeHTTP(w, r)
-		})
-	}
+func SetResponseHeaders(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, header := range DefaultResponseHeaders {
+			w.Header().Add(header.Field, header.Value)
+		}
+		h.ServeHTTP(w, r)
+	})
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -34,9 +34,10 @@ func TestSetViolationPenaltiesSkipsInvalidPenalties(t *testing.T) {
 		"TestViolation:2": 120,
 	}
 
+	SetHawkCreds(nil)
 	SetViolationPenalties(testViolations)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/violations", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -52,7 +53,7 @@ func TestSetViolationPenaltiesSkipsInvalidPenalties(t *testing.T) {
 }
 
 func TestSetResponseHeadersMiddleware(t *testing.T) {
-	h := HandleWithMiddleware(NewRouter(), []Middleware{SetResponseHeaders})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/__version__", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -52,7 +52,7 @@ func TestSetViolationPenaltiesSkipsInvalidPenalties(t *testing.T) {
 }
 
 func TestSetResponseHeadersMiddleware(t *testing.T) {
-	h := HandleWithMiddleware(NewRouter(), []Middleware{SetResponseHeaders()})
+	h := HandleWithMiddleware(NewRouter(), []Middleware{SetResponseHeaders})
 	req := httptest.NewRequest("GET", "/__version__", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)

--- a/reputation.go
+++ b/reputation.go
@@ -1,0 +1,240 @@
+package tigerblood
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"go.mozilla.org/mozlogrus"
+	"database/sql"
+	"net/http"
+	"io/ioutil"
+	"encoding/json"
+)
+
+func init() {
+	mozlogrus.Enable("tigerblood")
+}
+
+func ReputationHandler(w http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case "GET":
+		ReadReputationHandler(w, req)
+	case "POST":
+		CreateReputationHandler(w, req)
+	case "PUT":
+		UpdateReputationHandler(w, req)
+	case "DELETE":
+		DeleteReputationHandler(w, req)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// Route{
+// 	"ReadReputation",
+// 	"GET",
+// 	"/{ip:[[:punct:]\\/\\.\\w]{1,128}}", // see above note for all punct for IPs w/ colons e.g. 2001:db8::/32
+// 	ReadReputationHandler,
+// },
+// Route{
+// 	"CreateReputation",
+// 	"POST",
+// 	"/",
+// 	CreateReputationHandler,
+// },
+// Route{
+// 	"UpdateReputation",
+// 	"PUT",
+// 	"/{ip:[[:punct:]\\/\\.\\w]{1,128}}",
+// 	UpdateReputationHandler,
+// },
+// Route{
+// 	"DeleteReputation",
+// 	"DELETE",
+// 	"/{ip:[[:punct:]\\/\\.\\w]{1,128}}",
+// 	DeleteReputationHandler,
+// },
+
+
+// CreateReputation takes a JSON formatted IP reputation entry from
+// the http request and inserts it to the database.
+func CreateReputationHandler(w http.ResponseWriter, r *http.Request) {
+	var entry ReputationEntry
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.WithFields(log.Fields{"errno": BodyReadError}).Warnf(DescribeErrno(BodyReadError))
+		return
+	}
+	err = json.Unmarshal(body, &entry)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": JSONUnmarshalError}).Warnf(DescribeErrno(JSONUnmarshalError), err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if !IsValidReputationEntry(entry) {
+		if !IsValidReputationCIDROrIP(entry.IP) {
+			log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), entry.IP)
+		}
+		if !IsValidReputation(entry.Reputation) {
+			log.WithFields(log.Fields{"errno": InvalidReputationError}).Infof(DescribeErrno(InvalidReputationError), entry.Reputation)
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if db == nil {
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	err = db.InsertReputationEntry(nil, entry)
+	if _, ok := err.(CheckViolationError); ok {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Reputation is outside of valid range [0-100]"))
+	} else if _, ok := err.(DuplicateKeyError); ok {
+		w.WriteHeader(http.StatusConflict)
+		w.Write([]byte("Reputation is already set for that IP."))
+	} else if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	if err != nil {
+		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not insert reputation entry: %s", err)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+
+// UpdateReputation takes a JSON body from the http request and updates that reputation entry on the database.
+// The HTTP requests path has to contain the IP to be updated, in CIDR notation. The body can contain the IP address, or it can be omitted. For example:
+// {"Reputation": 50} or {"Reputation": 50, "IP":, "192.168.0.1"}. The IP in the JSON body will be ignored.
+func UpdateReputationHandler(w http.ResponseWriter, r *http.Request) {
+	ip, err := IPAddressFromHTTPPath(r.URL.Path)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": MissingIPError}).Infof(DescribeErrno(MissingIPError), r.URL.Path, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if !IsValidReputationCIDROrIP(ip) {
+		w.WriteHeader(http.StatusBadRequest)
+		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), ip)
+		return
+	}
+
+	var entry ReputationEntry
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": BodyReadError}).Warnf(DescribeErrno(BodyReadError))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = json.Unmarshal(body, &entry)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": JSONUnmarshalError}).Warnf(DescribeErrno(JSONUnmarshalError), err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	entry.IP = ip
+
+	if !IsValidReputationEntry(entry) {
+		if !IsValidReputationCIDROrIP(entry.IP) {
+			log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), entry.IP)
+		}
+		if !IsValidReputation(entry.Reputation) {
+			log.WithFields(log.Fields{"errno": InvalidReputationError}).Infof(DescribeErrno(InvalidReputationError), entry.Reputation)
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if db == nil {
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	err = db.UpdateReputationEntry(nil, entry)
+	if _, ok := err.(CheckViolationError); ok {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Reputation is outside of valid range [0-100]"))
+	} else if err == ErrNoRowsAffected {
+		w.WriteHeader(http.StatusNotFound)
+	} else if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not update reputation entry: %s", err)
+	} else if err == nil {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// DeleteReputation deletes an entry based on the IP address provided on the path
+func DeleteReputationHandler(w http.ResponseWriter, r *http.Request) {
+	ip, err := IPAddressFromHTTPPath(r.URL.Path)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": MissingIPError}).Infof(DescribeErrno(MissingIPError), r.URL.Path, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if !IsValidReputationCIDROrIP(ip) {
+		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), ip)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if db == nil {
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	err = db.DeleteReputationEntry(nil, ReputationEntry{IP: ip})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not delete reputation entry: %s", err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+
+// ReadReputation returns a JSON-formatted reputation entry from the database.
+func ReadReputationHandler(w http.ResponseWriter, r *http.Request) {
+	ip, err := IPAddressFromHTTPPath(r.URL.Path)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": MissingIPError}).Infof(DescribeErrno(MissingIPError), r.URL.Path, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if !IsValidReputationCIDROrIP(ip) {
+		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), ip)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if db == nil {
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	entry, err := db.SelectSmallestMatchingSubnet(ip)
+	if err == sql.ErrNoRows {
+		w.WriteHeader(http.StatusNotFound)
+		log.Debugf("No entries found for IP %s", ip)
+		return
+	} else if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not get reputation entry: %s", err)
+		return
+	}
+	json, err := json.Marshal(entry)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.WithFields(log.Fields{"errno": JSONMarshalError}).Warnf(DescribeErrno(JSONMarshalError), "reputation", err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(json)
+}

--- a/reputation.go
+++ b/reputation.go
@@ -14,6 +14,12 @@ func init() {
 }
 
 func ReputationHandler(w http.ResponseWriter, req *http.Request) {
+	SetResponseHeaders(w)
+
+	if RequireHawkAuth(w, req) != nil {
+		return
+	}
+
 	switch req.Method {
 	case "GET":
 		ReadReputationHandler(w, req)

--- a/reputation_test.go
+++ b/reputation_test.go
@@ -18,8 +18,9 @@ func TestReadReputationInvalidIP(t *testing.T) {
 	err = db.CreateTables()
 	assert.Nil(t, err)
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/2472814.124981275", nil))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
@@ -36,8 +37,9 @@ func TestReadReputationValidIP(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/127.0.0.1", nil))
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Nil(t, err)
@@ -57,8 +59,9 @@ func TestReadReputationNoEntry(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("GET", "/255.0.0.1", nil))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	assert.Nil(t, err)
@@ -72,8 +75,9 @@ func TestCreateEntry(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	assert.Equal(t, http.StatusCreated, recorder.Code)
@@ -89,8 +93,9 @@ func TestCreateEntry(t *testing.T) {
 
 func TestCreateEntryNoDB(t *testing.T) {
 	recorder := httptest.ResponseRecorder{}
+	SetHawkCreds(nil)
 	SetDB(nil)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
@@ -104,8 +109,9 @@ func TestCreateEntryInvalidJson(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1`)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Nil(t, err)
@@ -119,8 +125,9 @@ func TestCreateEntryInvalidIP(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1 -- SELECT(2)", "reputation": 200}`)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Nil(t, err)
@@ -134,8 +141,9 @@ func TestCreateEntryInvalidReputation(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 200}`)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Nil(t, err)
@@ -149,8 +157,9 @@ func TestUpdateEntry(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 25}`)))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
@@ -171,8 +180,9 @@ func TestUpdateEntryInvalidJson(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": `)))
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
@@ -181,7 +191,7 @@ func TestUpdateEntryNoDB(t *testing.T) {
 	recorder := httptest.ResponseRecorder{}
 
 	SetDB(nil)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/192.168.0.1", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 }
@@ -194,8 +204,9 @@ func TestDeleteEntry(t *testing.T) {
 	assert.Nil(t, err)
 	db.emptyReputationTable()
 
+	SetHawkCreds(nil)
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	h.ServeHTTP(&recorder, httptest.NewRequest("POST", "/", strings.NewReader(`{"IP": "192.168.0.1", "reputation": 20}`)))
 	recorder = httptest.ResponseRecorder{}
 	h.ServeHTTP(&recorder, httptest.NewRequest("DELETE", "/192.168.0.1", nil))
@@ -208,8 +219,9 @@ func TestDeleteEntry(t *testing.T) {
 func TestDeleteEntryNoDB(t *testing.T) {
 	recorder := httptest.ResponseRecorder{}
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 
+	SetHawkCreds(nil)
 	SetDB(nil)
 	h.ServeHTTP(&recorder, httptest.NewRequest("DELETE", "/192.168.0.1", nil))
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)

--- a/router.go
+++ b/router.go
@@ -1,114 +1,44 @@
 package tigerblood
 
 import (
-	"github.com/gorilla/mux"
 	"net/http"
 	"net/http/pprof"
 )
 
-
-func AttachProfiler(router *mux.Router) {
-	// Register pprof handlers
-	router.HandleFunc("/debug/pprof/", pprof.Index)
-	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-}
-
-func NewRouter() *mux.Router {
-	router := mux.NewRouter().StrictSlash(true)
+func NewRouter() *http.ServeMux {
+	router := http.NewServeMux()
 
 	if useProfileHandlers {
-		AttachProfiler(router)
+		// Register pprof handlers
+		router.HandleFunc("/debug/", pprof.Index)
+		router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	}
 
-	for _, route := range routes {
-		var handler http.Handler
+	router.HandleFunc("/__version__", VersionHandler)
+	router.HandleFunc("/__heartbeat__", HeartbeatHandler)
+	router.HandleFunc("/__lbheartbeat__", LoadBalancerHeartbeatHandler)
 
-		handler = route.HandlerFunc
-
-		router.
-			Methods(route.Method).
-			Path(route.Pattern).
-			Name(route.Name).
-			Handler(handler)
-	}
+	router.HandleFunc("/violations/", UpsertReputationByViolationHandler)
+	router.HandleFunc("/violations", ListViolationsHandler)
+	router.HandleFunc("/", ReputationHandler)
 
 	return router
 }
-
-type Route struct {
-	Name         string
-	Method       string
-	Pattern      string
-	HandlerFunc  http.HandlerFunc
-}
-
-type Routes []Route
 
 var UnauthedRoutes = map[string]bool{
 	"/__lbheartbeat__": true,
 	"/__heartbeat__": true,
 	"/__version__": true,
+}
+
+var UnauthedDebugRoutes = map[string]bool{
 	"/debug/pprof/": true,
+	"/debug/pprof/heap": true,
+	"/debug/pprof/block": true,
 	"/debug/pprof/cmdline": true,
 	"/debug/pprof/profile": true,
 	"/debug/pprof/symbol": true,
-}
-
-var routes = Routes{
-	Route{
-		"LoadBalancerHeartbeat",
-		"GET",
-		"/__lbheartbeat__",
-		LoadBalancerHeartbeatHandler,
-	},
-	Route{
-		"Heartbeat",
-		"GET",
-		"/__heartbeat__",
-		HeartbeatHandler,
-	},
-	Route{
-		"Version",
-		"GET",
-		"/__version__",
-		VersionHandler,
-	},
-	Route{
-		"ListViolations",
-		"GET",
-		"/violations",
-		ListViolationsHandler,
-	},
-	Route{
-		"UpsertReputationByViolation",
-		"PUT",
-		"/violations/{type:[[:punct:]\\w]{1,255}}",  // include all :punct: since gorilla/mux barfed trying to limit it to `:` (or as \x3a)
-		UpsertReputationByViolationHandler,
-	},
-	Route{
-		"ReadReputation",
-		"GET",
-		"/{ip:[[:punct:]\\/\\.\\w]{1,128}}", // see above note for all punct for IPs w/ colons e.g. 2001:db8::/32
-		ReadReputationHandler,
-	},
-	Route{
-		"CreateReputation",
-		"POST",
-		"/",
-		CreateReputationHandler,
-	},
-	Route{
-		"UpdateReputation",
-		"PUT",
-		"/{ip:[[:punct:]\\/\\.\\w]{1,128}}",
-		UpdateReputationHandler,
-	},
-	Route{
-		"DeleteReputation",
-		"DELETE",
-		"/{ip:[[:punct:]\\/\\.\\w]{1,128}}",
-		DeleteReputationHandler,
-	},
+	"/debug/pprof/goroutine": true,
 }

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -59,5 +59,9 @@ func SetViolationPenalties(newPenalties map[string]uint) {
 }
 
 func SetHawkCreds(credentials map[string]string) {
-	hawkData = NewHawkData(credentials)
+	if credentials == nil {
+		hawkData = nil
+	} else {
+		hawkData = NewHawkData(credentials)
+	}
 }

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -24,6 +24,11 @@ func SetDB(newDb *DB) {
 
 func SetProfileHandlers(profileHandlers bool) {
 	useProfileHandlers = profileHandlers
+
+	for route, _ := range UnauthedDebugRoutes {
+		UnauthedRoutes[route] = useProfileHandlers
+	}
+	log.Printf("Unauthed routes: %s", UnauthedRoutes)
 }
 
 func SetStatsdClient(newClient *statsd.Client) {

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -12,6 +12,7 @@ var statsdClient *statsd.Client = nil
 var violationPenalties map[string]uint = nil
 var violationPenaltiesJson []byte = nil
 var useProfileHandlers = false
+var hawkData *HawkData = nil
 
 func init() {
 	mozlogrus.Enable("tigerblood")
@@ -50,4 +51,8 @@ func SetViolationPenalties(newPenalties map[string]uint) {
 		log.WithFields(log.Fields{"errno": JSONMarshalError}).Warnf(DescribeErrno(JSONMarshalError), "violations", err)
 	}
 	violationPenaltiesJson = json
+}
+
+func SetHawkCreds(credentials map[string]string) {
+	hawkData = NewHawkData(credentials)
 }

--- a/unauthed_test.go
+++ b/unauthed_test.go
@@ -77,5 +77,5 @@ func TestDebugRoutesWhenProfileHandlersDisabled(t *testing.T) {
 	h.ServeHTTP(recorder, req)
 	res := recorder.Result()
 
-	assert.Equal(t, http.StatusMovedPermanently, res.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 }

--- a/unauthed_test.go
+++ b/unauthed_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLoadBalancerHeartbeatHandler(t *testing.T) {
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/__lbheartbeat__", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -25,7 +25,7 @@ func TestHeartbeatHandler(t *testing.T) {
 	assert.Nil(t, err)
 
 	SetDB(db)
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/__heartbeat__", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -37,7 +37,7 @@ func TestHeartbeatHandler(t *testing.T) {
 func TestHeartbeatHandlerWithoutDB(t *testing.T) {
 	SetDB(nil)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/__heartbeat__", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -47,7 +47,7 @@ func TestHeartbeatHandlerWithoutDB(t *testing.T) {
 }
 
 func TestVersionHandler(t *testing.T) {
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/__version__", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -59,7 +59,7 @@ func TestVersionHandler(t *testing.T) {
 func TestDebugRoutesWhenProfileHandlersEnabled(t *testing.T) {
 	SetProfileHandlers(true)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -71,7 +71,7 @@ func TestDebugRoutesWhenProfileHandlersEnabled(t *testing.T) {
 func TestDebugRoutesWhenProfileHandlersDisabled(t *testing.T) {
 	SetProfileHandlers(false)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/debug/pprof/", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)

--- a/violation.go
+++ b/violation.go
@@ -1,0 +1,128 @@
+package tigerblood
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"go.mozilla.org/mozlogrus"
+	"net/http"
+	"io/ioutil"
+	"encoding/json"
+	"strings"
+)
+
+func init() {
+	mozlogrus.Enable("tigerblood")
+}
+
+// Returns a list of known violations for debugging
+func ListViolationsHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	if violationPenalties == nil || violationPenaltiesJson == nil {
+		log.WithFields(log.Fields{"errno": MissingViolations}).Warnf(DescribeErrno(MissingViolations))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(violationPenaltiesJson)
+}
+
+// Route{
+// 	"UpsertReputationByViolation",
+// 	"PUT",
+// 	"/violations/{type:[[:punct:]\\w]{1,255}}",  // include all :punct: since gorilla/mux barfed trying to limit it to `:` (or as \x3a)
+// 	UpsertReputationByViolationHandler,
+// },
+
+// UpsertReputationByViolation takes a JSON body from the http request
+// and upserts the reputation entry on the database to the reputation
+// given in reputation violation.  The HTTP requests path has to
+// contain the IP to be updated, in CIDR notation. For example:
+// {"Violation": "password-reset-rate-limit-exceeded"}
+func UpsertReputationByViolationHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "PUT" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	splitPath := strings.Split(r.URL.Path, "/")
+	if len(splitPath) != 3 {
+		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	ip, err := IPAddressFromHTTPPath("/" + splitPath[2])
+
+	if err != nil {
+		log.WithFields(log.Fields{"errno": MissingIPError}).Infof(DescribeErrno(MissingIPError), r.URL.Path, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if !IsValidReputationCIDROrIP(ip) {
+		log.WithFields(log.Fields{"errno": InvalidIPError}).Infof(DescribeErrno(InvalidIPError), splitPath[2])
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": BodyReadError}).Warnf(DescribeErrno(BodyReadError))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	type ViolationBody struct {
+		Violation string
+	}
+	var entry ViolationBody
+	err = json.Unmarshal(body, &entry)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": JSONUnmarshalError}).Warnf(DescribeErrno(JSONUnmarshalError), err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if !IsValidViolationName(entry.Violation) {
+		log.WithFields(log.Fields{"errno": InvalidViolationTypeError}).Infof(DescribeErrno(InvalidViolationTypeError), entry.Violation)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if violationPenalties == nil {
+		log.WithFields(log.Fields{"errno": MissingViolations}).Warnf(DescribeErrno(MissingViolations))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// lookup violation weight in config map
+	var penalty, ok = violationPenalties[entry.Violation]
+	if !ok {
+		log.WithFields(log.Fields{"errno": MissingViolationTypeError}).Infof("Could not find violation type: %s", entry.Violation)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Violation type not found."))
+		return
+	}
+
+	if db == nil {
+		log.WithFields(log.Fields{"errno": MissingDB}).Warnf(DescribeErrno(MissingDB))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	err = db.InsertOrUpdateReputationPenalty(nil, ip, uint(penalty))
+	if _, ok := err.(CheckViolationError); ok {
+		log.WithFields(log.Fields{"errno": InvalidReputationError}).Warnf("Reputation is outside of valid range [0-100]")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Reputation is outside of valid range [0-100]"))
+	} else if err != nil {
+		log.WithFields(log.Fields{"errno": DBError}).Warnf("Could not update reputation entry by violation: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	} else if err == nil {
+		log.Debugf("Updated reputation for %s due to %d", ip, penalty)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/violation_test.go
+++ b/violation_test.go
@@ -16,9 +16,10 @@ func TestListViolations(t *testing.T) {
 		"TestViolation:2": 20,
 	}
 
+	SetHawkCreds(nil)
 	SetViolationPenalties(testViolations)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/violations", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -34,9 +35,10 @@ func TestListViolations(t *testing.T) {
 }
 
 func TestListViolationsMissingViolationsMiddleware(t *testing.T) {
+	SetHawkCreds(nil)
 	SetViolationPenalties(nil)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 	req := httptest.NewRequest("GET", "/violations", nil)
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, req)
@@ -58,9 +60,10 @@ func TestInsertReputationByViolation(t *testing.T) {
 	}
 
 	SetDB(db)
+	SetHawkCreds(nil)
 	SetViolationPenalties(testViolations)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 
 	t.Run("known", func (t *testing.T) {
 		// known violation type is subtracted from default reputation
@@ -103,10 +106,10 @@ func TestInsertReputationByViolationRequiresDB(t *testing.T) {
 		"TestViolation": 90,
 	}
 	SetViolationPenalties(testViolations)
-
+	SetHawkCreds(nil)
 	SetDB(nil)
 
-	h := HandleWithMiddleware(NewRouter(), []Middleware{})
+	h := NewRouter()
 
 	recorder := httptest.ResponseRecorder{}
 	h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/violations/192.168.0.1", strings.NewReader(`{"Violation": "TestViolation"}`)))

--- a/violation_test.go
+++ b/violation_test.go
@@ -91,10 +91,10 @@ func TestInsertReputationByViolation(t *testing.T) {
 		// test parsing invalid URL
 		recorder := httptest.ResponseRecorder{}
 		h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/violations", strings.NewReader(`{"Violation": "UnknownViolation"}`)))
-		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Equal(t, http.StatusMethodNotAllowed, recorder.Code) // matches list violations
 		recorder = httptest.ResponseRecorder{}
 		h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/violations////", strings.NewReader(`{"Violation": "UnknownViolation"}`)))
-		assert.Equal(t, http.StatusMovedPermanently, recorder.Code) // gorilla/mux redirect
+		assert.Equal(t, http.StatusMovedPermanently, recorder.Code) // redirect
 	})
 }
 


### PR DESCRIPTION
For [0.7](https://github.com/mozilla-services/tigerblood/releases/tag/0.7) in stage at 200 rps:

ELB latency gets to a lot more than 50ms: https://console.aws.amazon.com/ec2/home?region=us-east-1#LoadBalancers:search=tigerblood-sta-ELB-FVEMD2J6NPHS

nginx `$upstream_response_time` is up to 20ms: https://tigerblood-kibana.stage.mozaws.net/_plugin/kibana/#/visualize/create?indexPattern=%5Btigerblood.app.nginx.access_%5DYYYY-MM-DD&type=histogram&_a=(filters:!(),linked:!f,query:(query_string:(analyze_wildcard:!t,query:%27*%27)),vis:(aggs:!((id:%273%27,params:(field:upstream_response_time,orderBy:%272%27,size:20),schema:segment,type:terms),(id:%272%27,schema:metric,type:count)),type:histogram))&_g=()

Didn't see any app or nginx errors logged.

The EC2 instance is not hitting disk, CPU at 10% or less, and plenty of memory.

The docker container has enough memory and compute.

I can't find the RDS instance health, but the data set fits in memory so I don't think that's a bottleneck.

stage app server flamegraphs: https://gist.github.com/g-k/8880cc0164dbe2f7b5bcc827d3b6fc50

Changes:

* Remove remaining middleware and gorilla/mux router
* Don't sort by IP in the read SQL query (see also the commit message https://github.com/mozilla-services/tigerblood/commit/f1dab6cfc71287501e58211c71842ef130bc0b02) note: this probably won't matter until the DB gets much larger
* enable more debug routes: https://github.com/mozilla-services/tigerblood/compare/faster?expand=1#diff-56c3bb2da6c5ecf6872e89a554944453R13

Local perf testing:

Reads for 200 rps against IPs that exist.

`INSERT_TEST_IPS=1 CLIENT_TIMEOUT=500 RW_RATIO=1 RPS=200 SERVICE_URL=http://127.0.0.1:8080/ HAWK_ID=<> HAWK_KEY=<> NUM_TEST_IPS=100 node scripts/loadtest.js`

master: min: ~30, p99.9: ~80, max: ~100

<img width="943" alt="screen shot 2017-03-30 at 1 52 41 pm" src="https://cloud.githubusercontent.com/assets/226605/24518494/2d0f1880-1550-11e7-9454-c4e1f72a3aba.png">

this branch: min: ~25, p99.9: ~60, max: ~90

<img width="940" alt="screen shot 2017-03-30 at 1 52 13 pm" src="https://cloud.githubusercontent.com/assets/226605/24518477/1f788300-1550-11e7-8e76-9dd19c81cbfe.png">