### PR TITLE
More debug routes

### DIFF
--- a/router.go
+++ b/router.go
@@ -10,6 +10,10 @@ import (
 func AttachProfiler(router *mux.Router) {
 	// Register pprof handlers
 	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/mutex", pprof.Index)
+	router.HandleFunc("/debug/pprof/heap", pprof.Index)
+	router.HandleFunc("/debug/pprof/block", pprof.Index)
+	router.HandleFunc("/debug/pprof/goroutine", pprof.Index)
 	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
@@ -50,10 +54,17 @@ var UnauthedRoutes = map[string]bool{
 	"/__lbheartbeat__": true,
 	"/__heartbeat__": true,
 	"/__version__": true,
+}
+
+var UnauthedDebugRoutes = map[string]bool{
 	"/debug/pprof/": true,
 	"/debug/pprof/cmdline": true,
 	"/debug/pprof/profile": true,
 	"/debug/pprof/symbol": true,
+	"/debug/pprof/heap": true,
+	"/debug/pprof/mutex": true,
+	"/debug/pprof/block": true,
+	"/debug/pprof/goroutine": true,
 }
 
 var routes = Routes{

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -23,6 +23,11 @@ func SetDB(newDb *DB) {
 
 func SetProfileHandlers(profileHandlers bool) {
 	useProfileHandlers = profileHandlers
+
+	for route, _ := range UnauthedDebugRoutes {
+		UnauthedRoutes[route] = useProfileHandlers
+	}
+	log.Printf("Unauthed routes: %s", UnauthedRoutes)
 }
 
 func SetStatsdClient(newClient *statsd.Client) {

--- a/tigerblood.go
+++ b/tigerblood.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	log "github.com/Sirupsen/logrus"
 	"go.mozilla.org/mozlogrus"
+	"runtime"
 )
 
 var db *DB = nil
@@ -28,6 +29,12 @@ func SetProfileHandlers(profileHandlers bool) {
 		UnauthedRoutes[route] = useProfileHandlers
 	}
 	log.Printf("Unauthed routes: %s", UnauthedRoutes)
+
+	if profileHandlers {
+		runtime.SetMutexProfileFraction(5)
+	} else {
+		runtime.SetMutexProfileFraction(0)
+	}
 }
 
 func SetStatsdClient(newClient *statsd.Client) {


### PR DESCRIPTION
refs: https://github.com/mozilla-services/tigerblood/issues/61#issuecomment-294173720

Enable more profiling endpoints block, mutex, goroutine, etc. and disable them when profiling isn't enabled.

Functional Test:

w/ profiling enabled can hit debug routes:

... TIGERBLOOD_PROFILE=true ./tigerblood --config-file config.yml
» curl -Iw '%{http_code}' http://localhost:8080/debug/pprof/mutex 
HTTP/1.1 200 OK
Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; report-uri /__cspreport__
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
Date: Fri, 14 Apr 2017 20:12:54 GMT
Content-Length: 1339

200%                                                                       

w/ profiling disabled cannot hit debug routes:

... TIGERBLOOD_PROFILE=false ./tigerblood --config-file config.yml

» curl -Iw '%{http_code}' http://localhost:8080/debug/pprof/mutex 
HTTP/1.1 404 Not Found
Content-Security-Policy: default-src 'none'; frame-ancestors 'none'; report-uri /__cspreport__
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
Date: Fri, 14 Apr 2017 20:13:34 GMT
Content-Length: 19

404%                                                                  