### PR TITLE
fix allowing dots in violation types/names

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -37,7 +37,7 @@ func IsValidViolationPenalty(penalty uint64) bool {
 	return penalty >= 0 && penalty <= 100
 }
 
-var violationRegex = regexp.MustCompile(`^[:\w]{1,255}$`)
+var violationRegex = regexp.MustCompile(`^[:\.\w]{1,255}$`)
 
 // IsValidViolationName checks if a violation name matches [:\w]{1,255}
 func IsValidViolationName(name string) bool {

--- a/violation_test.go
+++ b/violation_test.go
@@ -55,6 +55,7 @@ func TestInsertReputationByViolation(t *testing.T) {
 
 	testViolations := map[string]uint{
 		"Test:Violation": 90,
+		"Test:Violation.name": 90,
 	}
 
 	SetDB(db)
@@ -66,7 +67,7 @@ func TestInsertReputationByViolation(t *testing.T) {
 	t.Run("known", func(t *testing.T) {
 		// known violation type is subtracted from default reputation
 		recorder := httptest.ResponseRecorder{}
-		h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/violations/192.168.0.1", strings.NewReader(`{"Violation": "Test:Violation"}`)))
+		h.ServeHTTP(&recorder, httptest.NewRequest("PUT", "/violations/192.168.0.1", strings.NewReader(`{"Violation": "Test:Violation.name"}`)))
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
 
 		entry, err := db.SelectSmallestMatchingSubnet("192.168.0.1")


### PR DESCRIPTION
Broke this as part of #68 but the fxa violations include dots.

r? @jvehent 