### PR TITLE
fix db config bugs that can result in performance issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ The following configuration options are available:
 | Option name                | Description                                                                              | Default           |
 |----------------------------|------------------------------------------------------------------------------------------|-------------------|
 | CREDENTIALS                | A map of hawk id-keys.                                                                   | -                 |
-| DATABASE\_MAX\_OPEN\_CONNS | The maximum amount of PostgreSQL database connections tigerblood will open               | 80                |
+| DATABASE\_MAX\_OPEN\_CONNS | The maximum amount of PostgreSQL database connections tigerblood will open               | 75                |
+| DATABASE\_MAX\_IDLE\_CONNS | The maximum number of idle connections to keep open for reuse                            | 75                |
+| DATABASE\_MAXLIFETIME      | Max lifetime per connection, 0 to not expire, or time.Duration to override (e.g., 30m)   | 0                 |
 | BIND\_ADDR                 | The host and port tigerblood will listen on for HTTP requests                            | 127.0.0.1:8080    |
 | DSN                        | The PostgreSQL data source name. Mandatory.                                              | -                 |
 | HAWK                       | true to enable Hawk authentication. If true is provided, credentials must be non-empty   | false             |

--- a/cmd/tigerblood/main.go
+++ b/cmd/tigerblood/main.go
@@ -51,7 +51,9 @@ func startRuntimeCollector() {
 func loadConfig() {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
-	viper.SetDefault("DATABASE_MAX_OPEN_CONNS", 80)
+	viper.SetDefault("DATABASE_MAX_OPEN_CONNS", 75)
+	viper.SetDefault("DATABASE_MAX_IDLE_CONNS", 75)
+	viper.SetDefault("DATABASE_MAXLIFETIME", "0")
 	viper.SetDefault("BIND_ADDR", "127.0.0.1:8080")
 	viper.SetDefault("STATSD_ADDR", "127.0.0.1:8125")
 	viper.SetDefault("STATSD_NAMESPACE", "tigerblood.")
@@ -90,13 +92,14 @@ func loadDB() *tigerblood.DB {
 	if err != nil {
 		log.Fatalf("Could not connect to database: %s", err)
 	}
+
 	db.SetMaxOpenConns(viper.GetInt("DATABASE_MAX_OPEN_CONNS"))
 	db.SetMaxIdleConns(viper.GetInt("DATABASE_MAX_IDLE_CONNS"))
 
 	if viper.GetString("DATABASE_MAXLIFETIME") == "0" {
-		db.SetConnMaxLifetime(time.Duration(0))
+		db.SetConnMaxLifetime(0)
 	} else {
-		lifetime, err := time.ParseDuration(viper.GetString("DATABASE_CONN_MAXLIFETIME"))
+		lifetime, err := time.ParseDuration(viper.GetString("DATABASE_MAXLIFETIME"))
 		if err != nil {
 			db.SetConnMaxLifetime(lifetime)
 		} else {

--- a/db.go
+++ b/db.go
@@ -97,8 +97,8 @@ func NewDB(dsn string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(200)
-	db.SetMaxIdleConns(200)  // default is 2: https://golang.org/src/database/sql/sql.go#L652
+	db.SetMaxOpenConns(75)
+	db.SetMaxIdleConns(75)   // default is 2: https://golang.org/src/database/sql/sql.go#L652
 	db.SetConnMaxLifetime(0) // don't timeout
 
 	newDB := &DB{


### PR DESCRIPTION
Fixes issue where unless TIGERBLOOD_DATABASE_MAX_IDLE_CONNS was set in
the environment, the default setting would be set to 0 resulting in a
new database connection being made for each query.

Remove reference to DATABASE_CONN_MAXLIFETIME and use
DATABASE_MAXLIFETIME.

Default database connection parameters to 75/75 for idle/max which
should fall below the typical default parameters for most database
installations.