### PR TITLE
Add static API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,16 @@ Response schema:
 
 ### Authorization
 
-All requests to the API must be authenticated with a [Hawk](https://github.com/hueniverse/hawk) authorization header. For example, if you're doing requests with Python's `requests` package, you can use [requests-hawk](https://github.com/mozilla-services/requests-hawk) to generate headers. [The Hawk readme](https://github.com/hueniverse/hawk#implementations) contains information on different implementations for other languages. Request bodies are validated by the server (https://github.com/hueniverse/hawk#payload-validation), but the server does not provide any mechanism for response validation.
+All requests to the API must be authenticated unless authentication has been disabled. This can occur with
+a [Hawk](https://github.com/hueniverse/hawk) authorization header, or with a static API key.
+
+With hawk, if you're doing requests with Python's `requests` package, you can use [requests-hawk](https://github.com/mozilla-services/requests-hawk) to generate headers. [The Hawk readme](https://github.com/hueniverse/hawk#implementations) contains information on different implementations for other languages. Request bodies are validated by the server (https://github.com/hueniverse/hawk#payload-validation), but the server does not provide any mechanism for response validation.
+
+If using static API keys, the `TIGERBLOOD_APIKEY` header needs to be set in the request.
+
+The configuration defines if hawk authentication is enabled and if API key authentication is enabled. They can be
+used individually, or both. If both methods are enabled, a client needs to only authenticate using one in order for
+the request to be authorized.
 
 ### Endpoints
 `{ip}` should be substituted for a CIDR-notation IP address or network.

--- a/README.md
+++ b/README.md
@@ -91,11 +91,6 @@ persist in Tigerblood while the process executes. Configuration for `file` is ju
 The `aws` exception module adds known AWS public IP subnets to the exception list, and are polled periodically. The `aws`
 module has no configuration options, and can be invoked by specifying `aws=` with no configuration parameter.
 
-## Authentication
-
-Tigerblood will authenticate requests using either Hawk style authentication, static API keys, or both. The `HAWK` and `APIKEY` configuration values can be used to control this behavior. With static API key authentication, the
-`TIGERBLOOD_APIKEY` header value should be set in the request.
-
 ## HTTP API
 
 Response schema:
@@ -125,7 +120,11 @@ a [Hawk](https://github.com/hueniverse/hawk) authorization header, or with a sta
 
 With hawk, if you're doing requests with Python's `requests` package, you can use [requests-hawk](https://github.com/mozilla-services/requests-hawk) to generate headers. [The Hawk readme](https://github.com/hueniverse/hawk#implementations) contains information on different implementations for other languages. Request bodies are validated by the server (https://github.com/hueniverse/hawk#payload-validation), but the server does not provide any mechanism for response validation.
 
-If using static API keys, the `TIGERBLOOD_APIKEY` header needs to be set in the request.
+If using static API keys, the `Authorization` header should be set to the API key value prefixed with "APIKey ".
+
+```
+Authorization: APIKey APIKEYVALUE
+```
 
 The configuration defines if hawk authentication is enabled and if API key authentication is enabled. They can be
 used individually, or both. If both methods are enabled, a client needs to only authenticate using one in order for

--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ The following configuration options are available:
 
 | Option name                | Description                                                                              | Default           |
 |----------------------------|------------------------------------------------------------------------------------------|-------------------|
-| CREDENTIALS                | A map of hawk id-keys.                                                                   | -                 |
 | DATABASE\_MAX\_OPEN\_CONNS | The maximum amount of PostgreSQL database connections tigerblood will open               | 75                |
 | DATABASE\_MAX\_IDLE\_CONNS | The maximum number of idle connections to keep open for reuse                            | 75                |
 | DATABASE\_MAXLIFETIME      | Max lifetime per connection, 0 to not expire, or time.Duration to override (e.g., 30m)   | 0                 |
 | BIND\_ADDR                 | The host and port tigerblood will listen on for HTTP requests                            | 127.0.0.1:8080    |
 | DSN                        | The PostgreSQL data source name. Mandatory.                                              | -                 |
 | HAWK                       | true to enable Hawk authentication. If true is provided, credentials must be non-empty   | false             |
+| HAWK_CREDENTIALS           | A map of hawk id-keys.                                                                   | -                 |
+| APIKEY                     | true to enable API key authentication. If true is provided, credentials must be non-empty                                     | -                 |
+| APIKEY_CREDENTIALS         | A map of API key identifier and key values                                               | -                 |
 | VIOLATION_PENALTIES        | A map of violation names to their reputation penalty weight 0 to 100 inclusive. Ignores violation names with dashes.          | -                 |
 | EXCEPTIONS                 | Exceptions configuration, see Exceptions section of README                               | -                 |
 | STATSD\_ADDR               | The host and port for statsd                                                             | 127.0.0.1:8125    |
@@ -53,7 +55,7 @@ The config file can be JSON, TOML, YAML, HCL, or a Java properties file. Keys do
     "DSN": "user=tigerblood dbname=tigerblood sslmode=disable",
     "BIND_ADDR": "127.0.0.1:8080",
     "HAWK": "yes",
-    "CREDENTIALS": {
+    "HAWK_CREDENTIALS": {
         "root": "toor"
     },
     "VIOLATION_PENALTIES": "rate_limit_exceeded=2"
@@ -88,6 +90,11 @@ persist in Tigerblood while the process executes. Configuration for `file` is ju
 
 The `aws` exception module adds known AWS public IP subnets to the exception list, and are polled periodically. The `aws`
 module has no configuration options, and can be invoked by specifying `aws=` with no configuration parameter.
+
+## Authentication
+
+Tigerblood will authenticate requests using either Hawk style authentication, static API keys, or both. The `HAWK` and `APIKEY` configuration values can be used to control this behavior. With static API key authentication, the
+`TIGERBLOOD_APIKEY` header value should be set in the request.
 
 ## HTTP API
 

--- a/auth.go
+++ b/auth.go
@@ -82,7 +82,7 @@ func RequireAuth() Middleware {
 	}
 }
 
-// APIKeyAuth authentications API key based requests, returns true if successful
+// APIKeyAuth authenticates API key based requests, returns true if successful
 func APIKeyAuth(r *http.Request, m *APIKeyData) bool {
 	hdr := r.Header.Get("TIGERBLOOD_APIKEY")
 	if hdr == "" {

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,100 @@
+package tigerblood
+
+import (
+	log "github.com/sirupsen/logrus"
+	"net/http"
+)
+
+// Bits used in authentication modes bitmask
+const (
+	AuthEnableHawk = 1 << iota
+	AuthEnableAPIKey
+)
+
+// authmodes is a bit mask indicating authentication modes to support and influences the
+// behavior of the RequireAuth handler.
+var authModes int
+
+var hawkData *HawkData
+var apiKeyData *APIKeyData
+
+// APIKeyData is configuration data representing valid API authentication keys, where
+// the key is just an identifier and the value is the actual secret.
+type APIKeyData struct {
+	credentials map[string]string
+}
+
+// SetAuthMask sets the forms of authentication tigerblood will accept for requests. mask
+// is a bitmask indicating the supported authentication types; if no bits are set authentication
+// is disabled.
+func SetAuthMask(mask int) {
+	authModes = mask
+}
+
+// SetHawkCredentials configures the credentials to be used for hawk authentication
+func SetHawkCredentials(credentials map[string]string) {
+	hawkData = NewHawkData(credentials)
+}
+
+// SetAPIKeyCredentials configures the credentials to be used for API key authentication
+func SetAPIKeyCredentials(credentials map[string]string) {
+	apiKeyData = NewAPIKeyData(credentials)
+}
+
+// NewAPIKeyData returns API key config data from a map of API key credentials
+func NewAPIKeyData(secrets map[string]string) *APIKeyData {
+	return &APIKeyData{
+		credentials: secrets,
+	}
+}
+
+// RequireAuth middleware for validating authentication credentials
+func RequireAuth() Middleware {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, ok := UnauthedRoutes[r.URL.Path]; ok {
+				// Authentication not required, continue
+				log.Debugf("Skipping auth for route: %s", r.URL.Path)
+				h.ServeHTTP(w, r)
+				return
+			}
+
+			if authModes == 0 {
+				// Authentication is disabled, continue
+				h.ServeHTTP(w, r)
+				return
+			}
+
+			success := false
+			if (authModes&AuthEnableAPIKey != 0) && r.Header.Get("TIGERBLOOD_APIKEY") != "" {
+				success = APIKeyAuth(r, apiKeyData)
+			} else if authModes&AuthEnableHawk != 0 {
+				success = HawkAuth(r, hawkData)
+			}
+			if !success {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			// Authentication successful, continue
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// APIKeyAuth authentications API key based requests, returns true if successful
+func APIKeyAuth(r *http.Request, m *APIKeyData) bool {
+	hdr := r.Header.Get("TIGERBLOOD_APIKEY")
+	if hdr == "" {
+		log.WithFields(log.Fields{"errno": APIKeyNotSpecified}).Warnf("apikey: no key specified")
+		return false
+	}
+
+	for _, v := range m.credentials {
+		if hdr == v {
+			return true
+		}
+	}
+	log.WithFields(log.Fields{"errno": APIKeyInvalid}).Warnf("apikey: invalid key specified")
+	return false
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -25,7 +25,7 @@ func TestMissingAuthorizationAPIKey(t *testing.T) {
 func TestInvalidAuthorizationAPIKeyEmptyConfig(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
 	assert.Nil(t, err)
-	req.Header.Set("TIGERBLOOD_APIKEY", "some_invalid_key")
+	req.Header.Set("Authorization", "APIKey some_invalid_key")
 	recorder := httptest.NewRecorder()
 	credentials := make(map[string]string)
 	SetAPIKeyCredentials(credentials)
@@ -38,7 +38,7 @@ func TestInvalidAuthorizationAPIKeyEmptyConfig(t *testing.T) {
 func TestInvalidAuthorizationAPIKeySetConfig(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
 	assert.Nil(t, err)
-	req.Header.Set("TIGERBLOOD_APIKEY", "some_invalid_key")
+	req.Header.Set("Authorization", "APIKey some_invalid_key")
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
 	SetAPIKeyCredentials(credentials)
@@ -51,7 +51,7 @@ func TestInvalidAuthorizationAPIKeySetConfig(t *testing.T) {
 func TestValidAuthorizationAPIKey(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
 	assert.Nil(t, err)
-	req.Header.Set("TIGERBLOOD_APIKEY", "valid_key2")
+	req.Header.Set("Authorization", "APIKey valid_key2")
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
 	SetAPIKeyCredentials(credentials)
@@ -115,7 +115,7 @@ func TestInvalidMixedAuthorizationEmptyConfig(t *testing.T) {
 func TestInvalidMixedAuthorizationAPIKey(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
 	assert.Nil(t, err)
-	req.Header.Set("TIGERBLOOD_APIKEY", "invalid_key")
+	req.Header.Set("Authorization", "APIKey invalid_key")
 	recorder := httptest.NewRecorder()
 	apicredentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
 	hawkcredentials := map[string]string{"fxa": "foobar"}
@@ -157,7 +157,7 @@ func TestInvalidMixedAuthorizationHawk(t *testing.T) {
 func TestValidMixedAuthorizationAPIKey(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
 	assert.Nil(t, err)
-	req.Header.Set("TIGERBLOOD_APIKEY", "valid_key2")
+	req.Header.Set("Authorization", "APIKey valid_key2")
 	recorder := httptest.NewRecorder()
 	apicredentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
 	hawkcredentials := map[string]string{"fxa": "foobar"}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,197 @@
+package tigerblood
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"github.com/stretchr/testify/assert"
+	"go.mozilla.org/hawk"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMissingAuthorizationAPIKey(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	recorder := httptest.NewRecorder()
+	credentials := make(map[string]string)
+	SetAPIKeyCredentials(credentials)
+	SetAuthMask(AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestInvalidAuthorizationAPIKeyEmptyConfig(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	req.Header.Set("TIGERBLOOD_APIKEY", "some_invalid_key")
+	recorder := httptest.NewRecorder()
+	credentials := make(map[string]string)
+	SetAPIKeyCredentials(credentials)
+	SetAuthMask(AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestInvalidAuthorizationAPIKeySetConfig(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	req.Header.Set("TIGERBLOOD_APIKEY", "some_invalid_key")
+	recorder := httptest.NewRecorder()
+	credentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
+	SetAPIKeyCredentials(credentials)
+	SetAuthMask(AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestValidAuthorizationAPIKey(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	req.Header.Set("TIGERBLOOD_APIKEY", "valid_key2")
+	recorder := httptest.NewRecorder()
+	credentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
+	SetAPIKeyCredentials(credentials)
+	SetAuthMask(AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
+func TestLoadbalancerEndpointsUnauthedAPIKey(t *testing.T) {
+	SetProfileHandlers(true)
+
+	for _, path := range []string{
+		"/__lbheartbeat__",
+		"/__heartbeat__",
+		"/__version__",
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/profile",
+		"/debug/pprof/symbol",
+	} {
+		req, err := http.NewRequest("GET", "http://foo.bar"+path, nil)
+		assert.Nil(t, err)
+		recorder := httptest.NewRecorder()
+		credentials := map[string]string{"fxa": "foobar"}
+		SetAPIKeyCredentials(credentials)
+		SetAuthMask(AuthEnableAPIKey)
+		handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+		handler.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+	}
+}
+
+func TestMissingMixedAuthorization(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	recorder := httptest.NewRecorder()
+	credentials := make(map[string]string)
+	SetHawkCredentials(credentials)
+	SetAPIKeyCredentials(credentials)
+	SetAuthMask(AuthEnableHawk | AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestInvalidMixedAuthorizationEmptyConfig(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	req.Header.Set("Authorization", "Hawk This is clearly not a hawk header")
+	recorder := httptest.NewRecorder()
+	credentials := make(map[string]string)
+	SetHawkCredentials(credentials)
+	SetAPIKeyCredentials(credentials)
+	SetAuthMask(AuthEnableHawk | AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestInvalidMixedAuthorizationAPIKey(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	req.Header.Set("TIGERBLOOD_APIKEY", "invalid_key")
+	recorder := httptest.NewRecorder()
+	apicredentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
+	hawkcredentials := map[string]string{"fxa": "foobar"}
+	SetHawkCredentials(hawkcredentials)
+	SetAPIKeyCredentials(apicredentials)
+	SetAuthMask(AuthEnableHawk | AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestInvalidMixedAuthorizationHawk(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json;charset=utf-8")
+	auth := hawk.NewRequestAuth(req,
+		&hawk.Credentials{
+			ID:   "fxa",
+			Key:  "invalid",
+			Hash: sha256.New,
+		},
+		0,
+	)
+	hash := auth.PayloadHash("application/json")
+	hash.Write([]byte("foo"))
+	auth.SetHash(hash)
+	req.Header.Set("Authorization", auth.RequestHeader())
+	recorder := httptest.NewRecorder()
+	apicredentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
+	hawkcredentials := map[string]string{"fxa": "foobar"}
+	SetHawkCredentials(hawkcredentials)
+	SetAPIKeyCredentials(apicredentials)
+	SetAuthMask(AuthEnableHawk | AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestValidMixedAuthorizationAPIKey(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	req.Header.Set("TIGERBLOOD_APIKEY", "valid_key2")
+	recorder := httptest.NewRecorder()
+	apicredentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
+	hawkcredentials := map[string]string{"fxa": "foobar"}
+	SetHawkCredentials(hawkcredentials)
+	SetAPIKeyCredentials(apicredentials)
+	SetAuthMask(AuthEnableHawk | AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
+func TestValidMixedAuthorizationHawk(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://foo.bar/", bytes.NewReader([]byte("foo")))
+	assert.Nil(t, err)
+	req.Header.Set("Content-Type", "application/json;charset=utf-8")
+	auth := hawk.NewRequestAuth(req,
+		&hawk.Credentials{
+			ID:   "fxa",
+			Key:  "foobar",
+			Hash: sha256.New,
+		},
+		0,
+	)
+	hash := auth.PayloadHash("application/json")
+	hash.Write([]byte("foo"))
+	auth.SetHash(hash)
+	req.Header.Set("Authorization", auth.RequestHeader())
+	recorder := httptest.NewRecorder()
+	apicredentials := map[string]string{"test": "valid_key", "test2": "valid_key2"}
+	hawkcredentials := map[string]string{"fxa": "foobar"}
+	SetHawkCredentials(hawkcredentials)
+	SetAPIKeyCredentials(apicredentials)
+	SetAuthMask(AuthEnableHawk | AuthEnableAPIKey)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
+	handler.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,3 +1,3 @@
-credentials: {"root":"toor"}
+hawk_credentials: {"root":"toor"}
 violation_penalties: request.blockIp=10,request.checkAuthenticated.block.devicesNotify=20
 profile: true

--- a/errors.go
+++ b/errors.go
@@ -82,6 +82,13 @@ const (
 	// FileNotFound file not found error
 	FileNotFound = iota
 
+	// API key authentication errors
+
+	// APIKeyNotSpecified indicates the header value was not found
+	APIKeyNotSpecified = 70
+	// APIKeyInvalid indicates the key was not a configured credential
+	APIKeyInvalid = iota
+
 	// Unknown errors
 
 	// UnknownError is for generic errors

--- a/hawk.go
+++ b/hawk.go
@@ -29,85 +29,66 @@ func NewHawkData(secrets map[string]string) *HawkData {
 	}
 }
 
-// RequireHawkAuth middleware for checking a hawk auth header
-func RequireHawkAuth(credentials map[string]string) Middleware {
-	m := NewHawkData(credentials)
-
-	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if _, ok := UnauthedRoutes[r.URL.Path]; ok {
-				// Authentication not required, continue
-				log.Debugf("Skipping auth for route: %s", r.URL.Path)
-				h.ServeHTTP(w, r)
-				return
-			}
-
-			// Validate the Hawk header format and credentials
-			auth, err := hawk.NewAuthFromRequest(r, m.lookupCredentials, m.lookupNonceNop)
-			if err != nil {
-				switch err.(type) {
-				case hawk.AuthFormatError:
-					log.WithFields(log.Fields{"errno": HawkAuthFormatError}).Warn(err)
-				case *hawk.CredentialError:
-					log.WithFields(log.Fields{"errno": HawkCredError}).Warn(err)
-				case hawk.AuthError:
-					{
-						switch err.(hawk.AuthError) {
-						case hawk.ErrNoAuth:
-							log.WithFields(log.Fields{"errno": HawkErrNoAuth}).Warn(err)
-						case hawk.ErrReplay:
-							log.WithFields(log.Fields{"errno": HawkReplayError}).Warn(err)
-						}
-					}
-				default:
-					log.WithFields(log.Fields{"errno": HawkOtherAuthError}).Warnf("other hawk auth error: %s", err)
+// HawkAuth authenticates hawk requests, returns true if successful.
+func HawkAuth(r *http.Request, m *HawkData) bool {
+	// Validate the Hawk header format and credentials
+	auth, err := hawk.NewAuthFromRequest(r, m.lookupCredentials, m.lookupNonceNop)
+	if err != nil {
+		switch err.(type) {
+		case hawk.AuthFormatError:
+			log.WithFields(log.Fields{"errno": HawkAuthFormatError}).Warn(err)
+		case *hawk.CredentialError:
+			log.WithFields(log.Fields{"errno": HawkCredError}).Warn(err)
+		case hawk.AuthError:
+			{
+				switch err.(hawk.AuthError) {
+				case hawk.ErrNoAuth:
+					log.WithFields(log.Fields{"errno": HawkErrNoAuth}).Warn(err)
+				case hawk.ErrReplay:
+					log.WithFields(log.Fields{"errno": HawkReplayError}).Warn(err)
 				}
-				w.WriteHeader(http.StatusUnauthorized)
-				return
 			}
-
-			// Validate the header MAC and skew
-			validationError := auth.Valid()
-			if validationError != nil {
-				log.WithFields(log.Fields{"errno": HawkValidationError}).Warnf("hawk validation error: %s", validationError)
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-
-			// Validate the payload hash of the request Content-Type and body
-			// assuming bodies will fit in memory always validate the body
-			contentType := r.Header.Get("Content-Type")
-			if r.Method != "GET" && r.Method != "DELETE" && contentType == "" {
-				log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warn("hawk: missing content-type")
-			}
-
-			mediaType, _, err := mime.ParseMediaType(contentType)
-			if err != nil && contentType != "" {
-				log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warnf("hawk: invalid content-type %s", err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-
-			buf, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				log.WithFields(log.Fields{"errno": HawkReadBodyError}).Warnf("hawk: error reading body %s", err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-
-			r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
-			hash := auth.PayloadHash(mediaType)
-			io.Copy(hash, ioutil.NopCloser(bytes.NewBuffer(buf)))
-			if !auth.ValidHash(hash) {
-				log.WithFields(log.Fields{"errno": HawkInvalidBodyHash}).Warnf("hawk: invalid payload hash")
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-
-			// Authentication successful, continue
-			h.ServeHTTP(w, r)
-		})
+		default:
+			log.WithFields(log.Fields{"errno": HawkOtherAuthError}).Warnf("other hawk auth error: %s", err)
+		}
+		return false
 	}
+
+	// Validate the header MAC and skew
+	validationError := auth.Valid()
+	if validationError != nil {
+		log.WithFields(log.Fields{"errno": HawkValidationError}).Warnf("hawk validation error: %s", validationError)
+		return false
+	}
+
+	// Validate the payload hash of the request Content-Type and body
+	// assuming bodies will fit in memory always validate the body
+	contentType := r.Header.Get("Content-Type")
+	if r.Method != "GET" && r.Method != "DELETE" && contentType == "" {
+		log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warn("hawk: missing content-type")
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil && contentType != "" {
+		log.WithFields(log.Fields{"errno": HawkMissingContentType}).Warnf("hawk: invalid content-type %s", err)
+		return false
+	}
+
+	buf, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.WithFields(log.Fields{"errno": HawkReadBodyError}).Warnf("hawk: error reading body %s", err)
+		return false
+	}
+
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+	hash := auth.PayloadHash(mediaType)
+	io.Copy(hash, ioutil.NopCloser(bytes.NewBuffer(buf)))
+	if !auth.ValidHash(hash) {
+		log.WithFields(log.Fields{"errno": HawkInvalidBodyHash}).Warnf("hawk: invalid payload hash")
+		return false
+	}
+
+	return true
 }
 
 func (h *HawkData) lookupNonceNop(nonce string, t time.Time, credentials *hawk.Credentials) bool {

--- a/hawk_test.go
+++ b/hawk_test.go
@@ -23,7 +23,9 @@ func TestMissingAuthorization(t *testing.T) {
 	assert.Nil(t, err)
 	recorder := httptest.NewRecorder()
 	credentials := make(map[string]string)
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCredentials(credentials)
+	SetAuthMask(AuthEnableHawk)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -34,7 +36,9 @@ func TestInvalidAuthorization(t *testing.T) {
 	req.Header.Set("Authorization", "Hawk This is clearly not a hawk header")
 	recorder := httptest.NewRecorder()
 	credentials := make(map[string]string)
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCredentials(credentials)
+	SetAuthMask(AuthEnableHawk)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -56,7 +60,9 @@ func TestInvalidPayload(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCredentials(credentials)
+	SetAuthMask(AuthEnableHawk)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -79,7 +85,9 @@ func TestValidPayload(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCredentials(credentials)
+	SetAuthMask(AuthEnableHawk)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }
@@ -103,7 +111,9 @@ func TestValidPayloadNoContentType(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCredentials(credentials)
+	SetAuthMask(AuthEnableHawk)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }
@@ -115,7 +125,8 @@ func TestExpiration(t *testing.T) {
 	req.Header.Set("Authorization", `Hawk id="fxa", mac="zcMu1EMcdseQ0J/LInTt73gHp3EiygoZnAC7KybGJBQ=", ts="1473887198", nonce="deYFZM4Z", hash="7wQDpR3QDtZYCfOpvQTEpR8cNz1dCX3sar9RLx5CmWk="`)
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"fxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCredentials(credentials)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }
@@ -136,7 +147,9 @@ func TestLoadbalancerEndpointsUnauthed(t *testing.T) {
 		assert.Nil(t, err)
 		recorder := httptest.NewRecorder()
 		credentials := map[string]string{"fxa": "foobar"}
-		handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+		SetHawkCredentials(credentials)
+		SetAuthMask(AuthEnableHawk)
+		handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
 		handler.ServeHTTP(recorder, req)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 	}
@@ -159,7 +172,9 @@ func TestMissingCredentialsReturns401(t *testing.T) {
 	req.Header.Set("Authorization", auth.RequestHeader())
 	recorder := httptest.NewRecorder()
 	credentials := map[string]string{"notFxa": "foobar"}
-	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireHawkAuth(credentials)})
+	SetHawkCredentials(credentials)
+	SetAuthMask(AuthEnableHawk)
+	handler := HandleWithMiddleware(EchoHandler, []Middleware{RequireAuth()})
 	handler.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 }


### PR DESCRIPTION
Adds another form of authentication (static API keys). This is intended
to ease integration with components with which implementing hawk may be
undesirable or not possible.

The additional form of authentication can be used in conjunction with
the existing hawk method.

Resolves #84