### PR TITLE
ci: fix docker cred env var names in deploy-dockerhub.sh

### DIFF
--- a/bin/ci/deploy-dockerhub.sh
+++ b/bin/ci/deploy-dockerhub.sh
@@ -22,7 +22,7 @@ function retry() {
 }
 
 # configure docker creds
-retry 3  echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
+retry 3  echo "$DOCKER_PASS" | docker login -u="$DOCKER_USER" --password-stdin
 
 # docker tag and push git branch to dockerhub
 if [ -n "$1" ]; then


### PR DESCRIPTION
Change:

* fix env vars for dockerhub deploy

I copied `bin/ci/deploy-dockerhub.sh` from tecken, but tigerblood uses DOCKER_USER instead of DOCKER_USERNAME and _PASS instead of _PASSWORD.

r? @ameihm0912 